### PR TITLE
setup.py: fix SPDX copyright

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 Henrik Sandklef
+# SPDX-FileCopyrightText: 2021 Konrad Weihmann
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
Add the correct SPDX copyright info

Closes #31