### PR TITLE
GitHub CI: Add test annotation

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,8 +28,13 @@ jobs:
     - name: Test
       run: |
         cd tests
-        ./all.sh
+        JUNIT_REPORT=1 ./all.sh
       shell: bash
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v2
+      if: always() # always run even if the previous step fails
+      with:
+        report_paths: '**/TEST-*.xml'
     - name: Install additional tooling
       run: |
         pip3 install reuse

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist
 build
 flict.egg-info
 
+TEST*.xml
 tests/all.log
 .pytest_cache
 .mypy_cache

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -17,11 +17,16 @@ LOG_FILE=$(dirname ${BASH_SOURCE[0]}/)/all.log
 
 rm -f $LOG_FILE
 
+# Switch to enable CI to generate a JUnit format report
+# to be consumed in GitHub pull request UI.
+if [ "${JUNIT_REPORT:-0}" -eq "1" ]; then
+    PYTEST_ARGS="--junitxml=TEST-pytest-junit.xml"
+fi
 
 echo
 inform "Python test scripts"
 echo "---------------------------------"
-sh -c "cd .. && pytest" || exit 1
+sh -c "cd .. && pytest ${PYTEST_ARGS}" || exit 1
 
 
 echo


### PR DESCRIPTION
Add a switch to make pytest generate a test report in junit format.
Add annotation step to GitHub action. This will consume the junit report
and annotate code changes with test results.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>