### PR TITLE
86 part 1: Fix Typo in Exception Name and Introduce Error Code 

### DIFF
--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -16,7 +16,7 @@ from flict.flictlib.flict_config import flict_version
 from flict.flictlib.format.factory import FormatFactory
 from flict.flictlib.project import Project
 from flict.flictlib.report import Report
-from flict.flictlib.return_codes import FLictException
+from flict.flictlib.return_codes import FlictException
 from flict.flictlib.return_codes import ReturnCodes
 
 import flict.flictlib.report
@@ -367,7 +367,7 @@ def simplify(args):
     try:
         license = flict_setup.license_handler.license_expression_list(lic_str)
     except:
-        raise FLictException(ReturnCodes.RET_INVALID_EXPRESSSION,
+        raise FlictException(ReturnCodes.RET_INVALID_EXPRESSSION,
                              "Invalid expression to simplify: " + str(args.license_expression))
 
     formatted = flict_setup.formatter.format_simplified(
@@ -394,7 +394,7 @@ def verify(args):
     elif present_and_set(args, 'license_expression'):
         verify_license_expression(args, flict_setup)
     else:
-        raise FLictException(ReturnCodes.RET_MISSING_ARGS,
+        raise FlictException(ReturnCodes.RET_MISSING_ARGS,
                              "Missing argument to the verify command")
 
 
@@ -414,7 +414,7 @@ def verify_license_expression(args, flict_setup):
 
         flict_print(flict_setup, formatted)
     except:
-        raise FLictException(ReturnCodes.RET_INVALID_EXPRESSSION,
+        raise FlictException(ReturnCodes.RET_INVALID_EXPRESSSION,
                              "Could not parse expression \"" + str(args.license_expression) + "\"")
 
 
@@ -423,7 +423,7 @@ def verify_project_file(args, flict_setup):
     try:
         project = Project(args.project_file, flict_setup.license_handler)
     except:
-        raise FLictException(ReturnCodes.RET_INVALID_PROJECT,
+        raise FlictException(ReturnCodes.RET_INVALID_PROJECT,
                              "Missing or invalid project file.")
 
     formatted = ""
@@ -470,7 +470,7 @@ def display_compatibility(args):
         compats = flict_setup.compatibility.check_compatibilities(
             licenses, args.extended_licenses)
     except:
-        raise FLictException(ReturnCodes.RET_INVALID_EXPRESSSION,
+        raise FlictException(ReturnCodes.RET_INVALID_EXPRESSSION,
                              "Could not parse license expression: " + str(args.licenses))
 
     formatted = flict_setup.formatter.format_compats(compats)
@@ -491,7 +491,7 @@ def suggest_outbound_candidate(args):
         output_outbound_license(flict_setup, lic_str,
                                 args.output_format, args.extended_licenses)
     except:
-        raise FLictException(ReturnCodes.RET_INVALID_EXPRESSSION,
+        raise FlictException(ReturnCodes.RET_INVALID_EXPRESSSION,
                              "Invalid license expression: " + str(args.licenses))
 
 
@@ -505,7 +505,7 @@ def main():
     if 'which' in args:
         try:
             args.func(args)
-        except FLictException as e:
+        except FlictException as e:
             flict_exit(e.error_code(), e.error_message())
 
     else:

--- a/flict/flictlib/return_codes.py
+++ b/flict/flictlib/return_codes.py
@@ -29,6 +29,7 @@ class ReturnCodes(Enum):
 
     RET_INVALID_PROJECT = (10, "Invalid project")
     RET_INVALID_EXPRESSSION = (11, "Invalid expression")
+    RET_FILE_NOT_FOUND = (12, "File not found")
 
     @classmethod
     def get_help(cls, indent="  "):

--- a/flict/flictlib/return_codes.py
+++ b/flict/flictlib/return_codes.py
@@ -46,7 +46,7 @@ class ReturnCodes(Enum):
         return indent + f"\n{indent}".join(ret)
 
 
-class FLictException(Exception):
+class FlictException(Exception):
 
     def __init__(self, error_code, error_message):
         self._error_code = error_code


### PR DESCRIPTION
These are basically stolen from @hesa 's #86 and should lower the burden of either fixing #86 or get the fixed branched more manageable.

Introduce the new error code for file not found.
Fix typo in flict exception name.