### PR TITLE
GitHub CI: Add token to test annotation

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,6 @@
 name: Push test pipeline
 
-on: [push, pull_request]
+on: [push, pull_request_target]
 
 jobs:
   gitlint:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,6 +47,7 @@ jobs:
       if: always() # always run even if the previous step fails
       with:
         report_paths: '**/TEST-*.xml'
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install additional tooling
       run: |
         pip3 install reuse


### PR DESCRIPTION
Add access token to test report annotation step to enable annotations
for PRs that were filed through external repositories.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>