### PR TITLE
ci: limit gitlint to pull-requests only

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,7 @@ jobs:
   gitlint:
       runs-on: ubuntu-latest
       name: GitLint
+      if: github.event_name == 'pull_request'
       steps:
         - name: Lint commits
           uses: aschbacd/gitlint-action@v1.0.1


### PR DESCRIPTION
as it produces failing pipelines on push builds in main

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>