### PR TITLE
Remove GPL specific if branch

### DIFF
--- a/flict/flictlib/translator.py
+++ b/flict/flictlib/translator.py
@@ -141,9 +141,6 @@ def read_translations(translations_file):
                 if "scancode" in le:
                     logger.main_logger.debug(" IGNORING since scancode")
                     pass
-                elif "gpl" in le or "gnu" in le:
-                    logger.main_logger.debug(" IGNORING since gpl...")
-                    pass
                 else:
                     #print(" OK ")
                     transl = item['spdx_id']


### PR DESCRIPTION
There's an if-branch where licenses, from the translation file, with
gpl in the name are discarded. This code is removed and thus gpl are
also, correctly so, translated.

Closes #124 