### PR TITLE
ci: fallback on specific python-debian version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -48,9 +48,11 @@ jobs:
       if: always() # always run even if the previous step fails
       with:
         report_paths: '**/TEST-*.xml'
+    # Install a specific version of python-debian, as there is a pending upstream bug
+    # with the latest version
     - name: Install additional tooling
       run: |
-        pip3 install reuse
+        pip3 install reuse python-debian==0.1.40
     - name: Reuse check
       run: |
         reuse lint


### PR DESCRIPTION
to reenable reuse integration.
See https://github.com/fsfe/reuse-tool/issues/427 for details

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>