### PR TITLE
126 hesa list transl relic

### DIFF
--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -238,6 +238,14 @@ def parse():
                            dest='license_group',
                            type=str,
                            help='output group (if any) for license')
+    parser_li.add_argument('-r', '--relicensing',
+                           dest='list_relicensing',
+                           action='store_true',
+                           help='List relicensing information')
+    parser_li.add_argument('-t', '--translations',
+                           dest='list_translation',
+                           action='store_true',
+                           help='List translation information')
 
     # display-compatibility
     parser_d = subparsers.add_parser(
@@ -304,6 +312,18 @@ def output_license_group(compatibility, license_handler, args):
                                                            flict_setup.license_handler,
                                                            args.license_group,
                                                            args.extended_licenses)
+    flict_print(flict_setup, formatted)
+
+
+def output_relicense_information(license_handler, args):
+    flict_setup = FlictSetup.get_setup(args)
+    formatted = flict_setup.formatter.format_relicense_information(license_handler)
+    flict_print(flict_setup, formatted)
+
+
+def output_translation_information(license_handler, args):
+    flict_setup = FlictSetup.get_setup(args)
+    formatted = flict_setup.formatter.format_translation_information(license_handler)
     flict_print(flict_setup, formatted)
 
 
@@ -382,6 +402,10 @@ def list_licenses(args):
                              flict_setup.license_handler, args)
     elif args.list_supported_license_groups:
         output_supported_license_groups(flict_setup)
+    elif args.list_relicensing:
+        output_relicense_information(flict_setup.license_handler, args)
+    elif args.list_translation:
+        output_translation_information(flict_setup.license_handler, args)
     else:
         output_supported_licenses(flict_setup)
 

--- a/flict/flictlib/format/dot_format.py
+++ b/flict/flictlib/format/dot_format.py
@@ -59,6 +59,12 @@ class DotFormatter(FormatInterface):
         result += "\n}\n"
         return result
 
+    def format_relicense_information(self, license_handler):
+        return None
+
+    def format_translation_information(self, license_handler):
+        return None
+    
 # help functions
 
 

--- a/flict/flictlib/format/dot_format.py
+++ b/flict/flictlib/format/dot_format.py
@@ -64,7 +64,7 @@ class DotFormatter(FormatInterface):
 
     def format_translation_information(self, license_handler):
         return None
-    
+
 # help functions
 
 

--- a/flict/flictlib/format/format.py
+++ b/flict/flictlib/format/format.py
@@ -45,3 +45,10 @@ class FormatInterface:
 
     def format_verified_license(self, license_expression, outbound_candidate):
         return "default implmentation | format__verified_license(): " + str(license_expression)
+
+    def format_relicense_information(self, license_handler):
+        return "default implmentation | format_relicense_information(): "
+
+    def format_translation_information(self, license_handler):
+        return "default implmentation | format_translation_information(): "
+

--- a/flict/flictlib/format/format.py
+++ b/flict/flictlib/format/format.py
@@ -44,7 +44,7 @@ class FormatInterface:
         return "default implmentation | format_simplified(): " + str(simplified)
 
     def format_verified_license(self, license_expression, outbound_candidate):
-        return "default implmentation | format__verified_license(): " + str(license_expression)
+        return "default implmentation | format_verified_license(): " + str(license_expression)
 
     def format_relicense_information(self, license_handler):
         return "default implmentation | format_relicense_information(): "

--- a/flict/flictlib/format/format.py
+++ b/flict/flictlib/format/format.py
@@ -14,41 +14,41 @@
 class FormatInterface:
 
     def format_support_licenses(self, supported_licenses):
-        return "default implmentation | format_support_licenses(): " + str(supported_licenses)
+        return "default implementation | format_support_licenses(): " + str(supported_licenses)
 
     def format_license_list(self, license_list):
-        return "default implmentation | format_license_list(): " + str(license_list)
+        return "default implementation | format_license_list(): " + str(license_list)
 
     def format_report(self, report):
-        return "default implmentation | format_report(): " + str(report)
+        return "default implementation | format_report(): " + str(report)
 
     def format_license_project(self, project):
-        return "default implmentation | format_license_combinations(): " + str(project)
+        return "default implementation | format_license_combinations(): " + str(project)
 
     def format_outbound_license(self, outbounds):
-        return "default implmentation | format_outbound_license(): " + str(outbounds)
+        return "default implementation | format_outbound_license(): " + str(outbounds)
 
     def format_license_combinations(self, combinations):
-        return "default implmentation | format_license_combinations(): " + str(combinations)
+        return "default implementation | format_license_combinations(): " + str(combinations)
 
     def format_compats(self, compats):
-        return "default implmentation | format_compats(): " + str(compats)
+        return "default implementation | format_compats(): " + str(compats)
 
     def format_supported_license_groups(self, license_groups):
-        return "default implmentation | format_supported_license_groups(): " + str(license_groups)
+        return "default implementation | format_supported_license_groups(): " + str(license_groups)
 
     def format_license_group(self, compatibility, license_handler, license_group, extended_licenses):
-        return "default implmentation | format_license_group(): " + str(license_group)
+        return "default implementation | format_license_group(): " + str(license_group)
 
     def format_simplified(self, license_expression, simplified):
-        return "default implmentation | format_simplified(): " + str(simplified)
+        return "default implementation | format_simplified(): " + str(simplified)
 
     def format_verified_license(self, license_expression, outbound_candidate):
-        return "default implmentation | format_verified_license(): " + str(license_expression)
+        return "default implementation | format_verified_license(): " + str(license_expression)
 
     def format_relicense_information(self, license_handler):
-        return "default implmentation | format_relicense_information(): "
+        return "default implementation | format_relicense_information(): "
 
     def format_translation_information(self, license_handler):
-        return "default implmentation | format_translation_information(): "
+        return "default implementation | format_translation_information(): "
 

--- a/flict/flictlib/format/json_format.py
+++ b/flict/flictlib/format/json_format.py
@@ -69,3 +69,9 @@ class JsonFormatter(FormatInterface):
                            "compatible": compat,
                            "outbound_candidate": outbound_candidate}
                           )
+
+    def format_relicense_information(self, license_handler):
+        return json.dumps(license_handler.relicensing_information()['original']['relicense_definitions'])
+
+    def format_translation_information(self, license_handler):
+        return json.dumps(license_handler.translation_information())

--- a/flict/flictlib/format/markdown_format.py
+++ b/flict/flictlib/format/markdown_format.py
@@ -4,7 +4,7 @@
 #
 # flict - FOSS License Compatibility Tool
 #
-# SPDX-FileCopyrightText: 2021 Henrik Sandklef
+# SPDX-FileCopyrightText: 2021 Henrik Sandklef, 2021 Konrad Weihmann
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -38,30 +38,19 @@ class MarkdownFormatter(FormatInterface):
         return output_compat_markdown(compats)
 
     def format_relicense_information(self, license_handler):
-        ret_str = None
-        for rel in license_handler.relicensing_information()['original']['relicense_definitions']:
-            if ret_str is not None:
+        ret_str = ""
+        for rel in license_handler.relicensing_information().get('original', {}).get('relicense_definitions', []):
+            if ret_str:
                 ret_str += "\n"
-            else:
-                ret_str = ""
-            lic = rel['spdx']
-            later_str = None
-            for later in rel['later']:
-                if later_str is None:
-                    later_str = later
-                else:
-                    later_str += ", " + later
-
-            ret_str += lic + " --> " + later_str
-        return "# Relicense information\n" + ret_str
+            later_str = rel.get('later', [])
+            ret_str += "{lic} --> {later}".format(lic=rel.get('spdx', 'NOASSERTATION'), later=", ".join(later_str))
+        return "# Translation information\n" + ret_str
 
     def format_translation_information(self, license_handler):
-        ret_str = None
+        ret_str = ""
         for transl_list in license_handler.translation_information():
             for transl in transl_list:
-                if ret_str is None:
-                    ret_str = ""
-                else:
+                if ret_str:
                     ret_str += "\n"
                 ret_str += transl + " <--- " + str(transl_list[transl])
         return "# Translation information\n" + ret_str

--- a/flict/flictlib/format/markdown_format.py
+++ b/flict/flictlib/format/markdown_format.py
@@ -37,6 +37,35 @@ class MarkdownFormatter(FormatInterface):
     def format_compats(self, compats):
         return output_compat_markdown(compats)
 
+    def format_relicense_information(self, license_handler):
+        ret_str = None
+        for rel in license_handler.relicensing_information()['original']['relicense_definitions']:
+            if ret_str is not None:
+                ret_str += "\n"
+            else:
+                ret_str = ""
+            lic = rel['spdx']
+            later_str = None
+            for later in rel['later']:
+                if later_str is None:
+                    later_str = later
+                else:
+                    later_str += ", " + later
+
+            ret_str += lic + " --> " + later_str
+        return "# Relicense information\n" + ret_str
+
+    def format_translation_information(self, license_handler):
+        ret_str = None
+        for transl_list in license_handler.translation_information():
+            for transl in transl_list:
+                if ret_str is None:
+                    ret_str = ""
+                else:
+                    ret_str += "\n"
+                ret_str += transl + " <--- " + str(transl_list[transl])
+        return "# Translation information\n" + ret_str
+
 
 def _compat_to_fmt(comp_left, comp_right, fmt):
     left = compat_interprets['left'][comp_left][fmt]
@@ -71,3 +100,4 @@ def output_compat_markdown(compats):
             result += main_license + " " + compat_text + " " + inner_license + "\n\n"
 
     return result
+

--- a/flict/flictlib/format/text_format.py
+++ b/flict/flictlib/format/text_format.py
@@ -4,7 +4,7 @@
 #
 # flict - FOSS License Compatibility Tool
 #
-# SPDX-FileCopyrightText: 2020 Henrik Sandklef
+# SPDX-FileCopyrightText: 2021 Henrik Sandklef, 2021 Konrad Weihmann
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -95,27 +95,19 @@ class TextFormatter(FormatInterface):
         return ret_str
 
     def format_relicense_information(self, license_handler):
-        ret_str = None
-        for rel in license_handler.relicensing_information()['original']['relicense_definitions']:
-            if ret_str is not None:
+        ret_str = ""
+        for rel in license_handler.relicensing_information().get('original', {}).get('relicense_definitions', []):
+            if ret_str:
                 ret_str += "\n"
-            else:
-                ret_str = ""
-            lic = rel['spdx']
-            later_list = []
-            for later in rel['later']:
-                later_list.append(later)
-
-            ret_str += lic + " --> " + str(later_list)
+            later_str = rel.get('later', [])
+            ret_str += "{lic} --> {later}".format(lic=rel.get('spdx', 'NOASSERTATION'), later=", ".join(later_str))
         return ret_str
 
     def format_translation_information(self, license_handler):
-        ret_str = None
+        ret_str = ""
         for transl_list in license_handler.translation_information():
             for transl in transl_list:
-                if ret_str is None:
-                    ret_str = ""
-                else:
+                if ret_str:
                     ret_str += "\n"
                 ret_str += transl + " <--- " + str(transl_list[transl])
         return ret_str

--- a/flict/flictlib/format/text_format.py
+++ b/flict/flictlib/format/text_format.py
@@ -93,3 +93,30 @@ class TextFormatter(FormatInterface):
             ret_str += lic + "\n"
             ret_str += "NOTE: the suggested outbound candidate licenses need to be manually reviewed."
         return ret_str
+
+    def format_relicense_information(self, license_handler):
+        ret_str = None
+        for rel in license_handler.relicensing_information()['original']['relicense_definitions']:
+            if ret_str is not None:
+                ret_str += "\n"
+            else:
+                ret_str = ""
+            lic = rel['spdx']
+            later_list = []
+            for later in rel['later']:
+                later_list.append(later)
+
+            ret_str += lic + " --> " + str(later_list)
+        return ret_str
+
+    def format_translation_information(self, license_handler):
+        ret_str = None
+        for transl_list in license_handler.translation_information():
+            for transl in transl_list:
+                if ret_str is None:
+                    ret_str = ""
+                else:
+                    ret_str += "\n"
+                ret_str += transl + " <--- " + str(transl_list[transl])
+        return ret_str
+

--- a/flict/flictlib/license.py
+++ b/flict/flictlib/license.py
@@ -110,12 +110,15 @@ class LicenseHandler:
     def read_symbols(self, translations_files):
         symbols = []
         symbols_map = {}
+        self.translations = []
         for translations_file in translations_files.split():
             #print("reading translation file: " + str(translations_file))
             translation_data = read_translations(translations_file)
+            self.translations.append(translation_data)
             for lic_key in translation_data:
                 #print("lic_key:  \"" + str(lic_key) + "\"")
                 #print("  lic_alias:  " + str(translation_data[lic_key] ))
+                #print("transl: " + str(len(self.translations)))
                 if lic_key not in symbols_map:
                     symbols_map[lic_key] = set()
                 for val in translation_data[lic_key]:
@@ -431,6 +434,14 @@ class LicenseHandler:
                     new_list.append(lep_item)
 
         return new_list
+
+    def relicensing_information(self):
+        if self.relicense_map is None:
+            self.relicense_map = read_relicense_file(self.relicense_file)
+        return self.relicense_map
+
+    def translation_information(self):
+        return self.translations
 
 
 def _debug_license_expression_set_list(ilel):


### PR DESCRIPTION
Closes #126 

These commits add (to the `list` command) the options:

* `-r` - to see relicensing information
* `-t` - to see translation information 