### PR TITLE
flict_config: add user configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Either create a json file at `~/.flict.cfg` or at a path defined by environment 
 | scancode-file     | -sf --scancode-file     |
 | translations-file | -tf --translations-file |
 
+### Example user configuration
+
+```json
+{
+    "matrix-file": "/my/very/own/osadl-matrix.csv",
+    "output-format": "text",
+    "scancode-file": "/my/secret/stash/scancode-licenses.json"
+}
+```
+
 ## Policy report
 
 To the above report you can apply your own policy (see [SETTINGS](SETTINGS.md)). Applying this will create a policy report with your policy applied to the suggested outbound license from the usual report and with some complementary information.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ This is currently rewritten and not available.
 
 Using this format you can create txt, html, pdf and what format pandoc can create from markdown.
 
+## User specific configuration
+
+You can create a user specific configuration for the tool that defines a few default parameters to your choices.
+Either create a json file at `~/.flict.cfg` or at a path defined by environment variable `FLICT_USERCONFIG`.
+
+| key               | sets CLI option         |
+| ----------------- | ----------------------- |
+| group-file        | -gf --group-file        |
+| matrix-file       | -mf --matrix-file       |
+| output-format     | -of --output-format     |
+| relicense-file    | -rf --relicense-file    |
+| scancode-file     | -sf --scancode-file     |
+| translations-file | -tf --translations-file |
+
 ## Policy report
 
 To the above report you can apply your own policy (see [SETTINGS](SETTINGS.md)). Applying this will create a policy report with your policy applied to the suggested outbound license from the usual report and with some complementary information.

--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -43,7 +43,6 @@ OUTPUT_FORMAT_JSON = "JSON"
 OUTPUT_FORMAT_TEXT = "text"
 OUTPUT_FORMAT_MARKDOWN = "markdown"
 OUTPUT_FORMAT_DOT = "dot"
-DEFAULT_OUTPUT_FORMAT = OUTPUT_FORMAT_JSON
 
 DATE_FMT = '%Y-%m-%d'
 
@@ -170,8 +169,8 @@ def parse():
                         dest='output_format',
                         help="output format. Avilable formats: " + OUTPUT_FORMAT_JSON + ", " + OUTPUT_FORMAT_TEXT + ", " +
                         OUTPUT_FORMAT_MARKDOWN + ", " + OUTPUT_FORMAT_DOT +
-                        ". Defaults to " + DEFAULT_OUTPUT_FORMAT,
-                        default=DEFAULT_OUTPUT_FORMAT)
+                        ". Defaults to " + flict_config.DEFAULT_OUTPUT_FORMAT,
+                        default=flict_config.DEFAULT_OUTPUT_FORMAT)
 
     parser.add_argument('-v', '--verbose',
                         action='store_true',

--- a/flict/flictlib/flict_config.py
+++ b/flict/flictlib/flict_config.py
@@ -2,13 +2,30 @@
 #
 # flict - FOSS License Compatibility Tool
 #
-# SPDX-FileCopyrightText: 2020 Henrik Sandklef
+# SPDX-FileCopyrightText: 2020 Henrik Sandklef, 2021 Konrad Weihmann
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 ###################################################################
 
+import json
 import os
+
+
+def read_user_config():
+    for path in [
+        os.environ.get('FLICT_USERCONFIG'),
+        os.path.join(os.environ.get('HOME'), '.flict.cfg')
+    ]:
+        try:
+            with open(path) as i:
+                return json.load(i)
+        except Exception: # noqa: S110 - it's okay ignore all errors here
+            pass
+    return {}
+
+
+_userconfig = read_user_config()
 
 flict_version = "0.1"
 
@@ -23,8 +40,9 @@ DEFAULT_RELICENSE_BASE_FILE = "relicense.json"
 DEFAULT_SCANCODE_BASE_FILE = "scancode-licenses.json"
 DEFAULT_MATRIX_BASE_FILE = "osadl-matrix.csv"
 
-DEFAULT_TRANSLATIONS_FILE = os.path.join(VAR_DIR, DEFAULT_TRANSLATIONS_BASE_FILE)
-DEFAULT_GROUP_FILE = os.path.join(VAR_DIR, DEFAULT_GROUP_BASE_FILE)
-DEFAULT_RELICENSE_FILE = os.path.join(VAR_DIR, DEFAULT_RELICENSE_BASE_FILE)
-DEFAULT_SCANCODE_FILE = os.path.join(VAR_DIR, DEFAULT_SCANCODE_BASE_FILE)
-DEFAULT_MATRIX_FILE = os.path.join(VAR_DIR, DEFAULT_MATRIX_BASE_FILE)
+DEFAULT_TRANSLATIONS_FILE = _userconfig.get('translations-file', os.path.join(VAR_DIR, DEFAULT_TRANSLATIONS_BASE_FILE))
+DEFAULT_GROUP_FILE = _userconfig.get('group-file', os.path.join(VAR_DIR, DEFAULT_GROUP_BASE_FILE))
+DEFAULT_RELICENSE_FILE = _userconfig.get('relicense-file', os.path.join(VAR_DIR, DEFAULT_RELICENSE_BASE_FILE))
+DEFAULT_SCANCODE_FILE = _userconfig.get('scancode-file', os.path.join(VAR_DIR, DEFAULT_SCANCODE_BASE_FILE))
+DEFAULT_MATRIX_FILE = _userconfig.get('matrix-file', os.path.join(VAR_DIR, DEFAULT_MATRIX_BASE_FILE))
+DEFAULT_OUTPUT_FORMAT = _userconfig.get('output-format', "JSON")


### PR DESCRIPTION
a file either found at $FLICT_USERCONFIG or ~/.flict.cfg can override
the defaults for several input file paths and the output format.

Move DEFAULT_OUTPUT_FORMAT ot flict_config module.
Add documentation on this new feature and the supported
options to README.md.

Closes #129

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>