### PR TITLE
Hesa add yocto license exprs

### DIFF
--- a/flict/var/translation.json
+++ b/flict/var/translation.json
@@ -7,6 +7,71 @@
     },
     "translations": [
         {
+            "license_expression": "AFL-1",
+            "spdx_id": "AFL-1.2",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AFL-2",
+            "spdx_id": "AFL-2.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AFLv1",
+            "spdx_id": "AFL-1.2",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AFLv2",
+            "spdx_id": "AFL-2.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AGPL-3",
+            "spdx_id": "AGPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AGPL-3+",
+            "spdx_id": "AGPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AGPL-3.0",
+            "spdx_id": "AGPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AGPL-3.0+",
+            "spdx_id": "AGPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AGPLv3",
+            "spdx_id": "AGPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AGPLv3+",
+            "spdx_id": "AGPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AGPLv3.0",
+            "spdx_id": "AGPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "AGPLv3.0+",
+            "spdx_id": "AGPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "Apache-2",
+            "spdx_id": "Apache-2.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
             "license_expression": "apache-1.0",
             "spdx_id": "Apache-1.0"
         },
@@ -19,20 +84,330 @@
             "spdx_id": "Apache-2.0"
         },
         {
+            "license_expression": "Apachev2",
+            "spdx_id": "Apache-2.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "Artistic-1",
+            "spdx_id": "Artistic-1.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "Artisticv1",
+            "spdx_id": "Artistic-1.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
             "license_expression": "BSD",
             "spdx_id": "BSD-3-Clause"
+        },
+        {
+            "license_expression": "BSD-0-Clause",
+            "spdx_id": "0BSD",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "CDDL-1",
+            "spdx_id": "CDDL-1.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "CDDLv1",
+            "spdx_id": "CDDL-1.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "EPLv1.0",
+            "spdx_id": "EPL-1.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "FreeType",
+            "spdx_id": "FTL",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-1",
+            "spdx_id": "GPL-1.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-1+",
+            "spdx_id": "GPL-1.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-1.0",
+            "spdx_id": "GPL-1.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-1.0+",
+            "spdx_id": "GPL-1.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-2",
+            "spdx_id": "GPL-2.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-2+",
+            "spdx_id": "GPL-2.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-2.0",
+            "spdx_id": "GPL-2.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-2.0+",
+            "spdx_id": "GPL-2.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-3",
+            "spdx_id": "GPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-3+",
+            "spdx_id": "GPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-3.0",
+            "spdx_id": "GPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPL-3.0+",
+            "spdx_id": "GPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv1",
+            "spdx_id": "GPL-1.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv1+",
+            "spdx_id": "GPL-1.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv1.0",
+            "spdx_id": "GPL-1.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv1.0+",
+            "spdx_id": "GPL-1.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv2",
+            "spdx_id": "GPL-2.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv2+",
+            "spdx_id": "GPL-2.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv2.0",
+            "spdx_id": "GPL-2.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv2.0+",
+            "spdx_id": "GPL-2.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv3",
+            "spdx_id": "GPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv3+",
+            "spdx_id": "GPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv3.0",
+            "spdx_id": "GPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "GPLv3.0+",
+            "spdx_id": "GPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPL-2.0",
+            "spdx_id": "LGPL-2.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPL-2.0+",
+            "spdx_id": "LGPL-2.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPL-2.1",
+            "spdx_id": "LGPL-2.1-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPL-2.1+",
+            "spdx_id": "LGPL-2.1-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPL-3.0",
+            "spdx_id": "LGPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPL-3.0+",
+            "spdx_id": "LGPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPL2.1",
+            "spdx_id": "LGPL-2.1-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPL2.1+",
+            "spdx_id": "LGPL-2.1-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPLv2",
+            "spdx_id": "LGPL-2.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPLv2+",
+            "spdx_id": "LGPL-2.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPLv2.0",
+            "spdx_id": "LGPL-2.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPLv2.0+",
+            "spdx_id": "LGPL-2.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPLv2.1",
+            "spdx_id": "LGPL-2.1-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPLv2.1+",
+            "spdx_id": "LGPL-2.1-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPLv3",
+            "spdx_id": "LGPL-3.0-only",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "LGPLv3+",
+            "spdx_id": "LGPL-3.0-or-later",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "MIT-X",
+            "spdx_id": "MIT",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "MIT-style",
+            "spdx_id": "MIT",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
         },
         {
             "license_expression": "mit",
             "spdx_id": "MIT"
         },
         {
+            "license_expression": "MPL-1",
+            "spdx_id": "MPL-1.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "MPLv1",
+            "spdx_id": "MPL-1.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "MPLv1.1",
+            "spdx_id": "MPL-1.1",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "MPLv2",
+            "spdx_id": "MPL-2.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
             "license_expression": "mpl-1.1",
             "spdx_id": "MPL-1.1"
         },
         {
+            "license_expression": "Nauman",
+            "spdx_id": "Naumen",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
             "license_expression": "openssl",
             "spdx_id": "OpenSSL"
+        },
+        {
+            "license_expression": "PSF",
+            "spdx_id": "PSF-2.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "PSFv2",
+            "spdx_id": "PSF-2.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "Python-2",
+            "spdx_id": "Python-2.0",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "SGIv1",
+            "spdx_id": "SGI-1",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "openssl",
+            "spdx_id": "OpenSSL",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "tcl",
+            "spdx_id": "TCL",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
+        },
+        {
+            "license_expression": "vim",
+            "spdx_id": "Vim",
+            "comment": "Origin: http://git.yoctoproject.org/cgit/cgit.cgi/poky/plain/meta/conf/licenses.conf"
         }
     ]
 }


### PR DESCRIPTION
With these commits we can check more packages with licenses declared by Yocto. This is done via `translations` (think aliases).