### PR TITLE
Reenable policy report

### DIFF
--- a/example-data/flict-policy.json
+++ b/example-data/flict-policy.json
@@ -1,0 +1,12 @@
+{
+    "policy": {
+        "avoidlist": [
+            "Libpng"
+        ],
+        "denylist": [
+            "FTL",
+            "GPL-3.0-or-later",
+            "MIT"
+        ]
+    }
+}

--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -14,6 +14,7 @@ from flict.flictlib.license import decode_license_expression
 from flict.flictlib.compatibility import Compatibility
 from flict.flictlib.flict_config import flict_version
 from flict.flictlib.format.factory import FormatFactory
+from flict.flictlib.policy import Policy
 from flict.flictlib.project import Project
 from flict.flictlib.report import Report
 from flict.flictlib.return_codes import FlictException
@@ -272,12 +273,15 @@ def parse():
         'policy-report', help='create report with license policy applied')
     parser_p.set_defaults(which="policy-report", func=policy_report)
     parser_p.add_argument('--license-policy-file', '-lpf',
-                          type=argparse.FileType('r'),
+                          type=str,
                           dest='policy_file',
-                          help='file with license policy')
+                          help='file with license policy',
+                          default=None)
     parser_p.add_argument('--compliance-report-file', '-crf',
-                          type=argparse.FileType('r'),
-                          help='file with report as produced using "verify"')
+                          type=str,
+                          dest='report_file',
+                          help='file with report as produced using "verify"',
+                          default=None)
 
     args = parser.parse_args()
 
@@ -518,7 +522,13 @@ def suggest_outbound_candidate(args):
 
 
 def policy_report(args):
-    print("polict_report: " + str(args))
+    flict_setup = FlictSetup.get_setup(args)
+    compliance_report = read_compliance_report(args.report_file)
+    policy = Policy(args.policy_file)
+    policy_report = policy.report(compliance_report)
+    formatted = flict_setup.formatter.format_policy_report(policy_report)
+    flict_print(flict_setup, formatted)
+    return policy_report.get("policy_outbounds").get("policy_result")
 
 
 def main():

--- a/flict/flictlib/format/format.py
+++ b/flict/flictlib/format/format.py
@@ -52,3 +52,6 @@ class FormatInterface:
     def format_translation_information(self, license_handler):
         return "default implementation | format_translation_information(): "
 
+    def format_policy_report(self, policy_report):
+        return "default implementation | format_policy_report(): "
+

--- a/flict/flictlib/format/json_format.py
+++ b/flict/flictlib/format/json_format.py
@@ -75,3 +75,6 @@ class JsonFormatter(FormatInterface):
 
     def format_translation_information(self, license_handler):
         return json.dumps(license_handler.translation_information())
+
+    def format_policy_report(self, policy_report):
+        return json.dumps(policy_report)

--- a/flict/flictlib/format/markdown_format.py
+++ b/flict/flictlib/format/markdown_format.py
@@ -55,6 +55,38 @@ class MarkdownFormatter(FormatInterface):
                 ret_str += transl + " <--- " + str(transl_list[transl])
         return "# Translation information\n" + ret_str
 
+    def format_policy_report(self, policy_report):
+        outbounds = policy_report.get("policy_outbounds")
+        meta = policy_report.get("meta")
+        ret_str = "# Policy report\n\n"
+        ret_str += "## About\n\n"
+        ret_str += "* date: " + meta.get("start") + "\n\n"
+        ret_str += "* user: " + meta.get("user") + "\n\n"
+        policy_result = outbounds.get("policy_result")
+        ret_str += "## Result\n\n"
+        ret_str += "Policy result: "
+        if policy_result == 0:
+            ret_str += "OK"
+        elif policy_result == 1:
+            ret_str += "OK, with licenses to avoid"
+        elif policy_result == 2:
+            ret_str += "Failed identifying outbound license"
+        ret_str += "\n\n"
+        ret_str += "## Suggested outbound licenses \n\n"
+        ret_str += "### Allowed\n\n"
+        for lic in outbounds.get("allowed"):
+            ret_str += " * " + lic + "\n"
+        ret_str += "\n\n"
+        ret_str += "### Avoided\n\n"
+        for lic in outbounds.get("avoided"):
+            ret_str += " * " + lic + "\n"
+        ret_str += "\n\n"
+        ret_str += "### Denied\n\n"
+        for lic in outbounds.get("denied"):
+            ret_str += " * " + lic + "\n"
+
+        return ret_str
+
 
 def _compat_to_fmt(comp_left, comp_right, fmt):
     left = compat_interprets['left'][comp_left][fmt]

--- a/flict/flictlib/format/text_format.py
+++ b/flict/flictlib/format/text_format.py
@@ -112,3 +112,18 @@ class TextFormatter(FormatInterface):
                 ret_str += transl + " <--- " + str(transl_list[transl])
         return ret_str
 
+    def format_policy_report(self, policy_report):
+        outbounds = policy_report.get("policy_outbounds")
+        ret_str = "Status: "
+        policy_result = outbounds.get("policy_result")
+        if policy_result == 0:
+            ret_str += "OK"
+        elif policy_result == 1:
+            ret_str += "OK, with licenses to avoid"
+        elif policy_result == 2:
+            ret_str += "Failed identifying outbound license"
+        ret_str += "\n"
+        ret_str += "Allowed (suggested) outbound licenses: " + str(outbounds.get("allowed", "")) + "\n"
+        ret_str += "Avoided (suggested) outbound licenses: " + str(outbounds.get("avoid", "")) + "\n"
+        ret_str += "Denied (suggested) outbound licenses: " + str(outbounds.get("denied", ""))
+        return ret_str

--- a/flict/flictlib/policy.py
+++ b/flict/flictlib/policy.py
@@ -32,10 +32,12 @@ class Policy:
         if self.policy_report['policy'] is None:
             return None
 
+        policy = self.policy_report['policy']['policy']
+
         outbounds = report['licensing']['outbound_candidates']
-        allowed = self.policy_report['policy']['policy']['allowlist']
-        avoid = self.policy_report['policy']['policy']['avoidlist']
-        denied = self.policy_report['policy']['policy']['denylist']
+        allowed = policy.get('allowlist', [])
+        avoid = policy.get('avoidlist', [])
+        denied = policy.get('denylist', [])
 
         #nr_outbounds = len(outbounds)
 
@@ -55,7 +57,7 @@ class Policy:
 
         policy_outbounds = {}
         policy_outbounds['allowed'] = list(allowed_outbound_candidates)
-        policy_outbounds['avoid'] = list(avoid_outbound_candidates)
+        policy_outbounds['avoided'] = list(avoid_outbound_candidates)
         policy_outbounds['denied'] = list(denied_outbound_candidates)
 
         if len(policy_outbounds['allowed']) > 0:


### PR DESCRIPTION
These commits brings back the policy reporting.

To try it out:
```
$ flict verify -pf example-data/europe-small.json > /tmp/europe-report.json
$ flict policy-report  -crf /tmp/europe-report.json -lpf example-data/flict-policy.json 
```

or with markdown output:
```
$ flict verify -pf example-data/europe-small.json > /tmp/europe-report.json
$ flict -of markdown policy-report  -crf /tmp/europe-report.json -lpf example-data/flict-policy.json 
```