### PR TITLE
Move Makefile away from top dir

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2021 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+FMT="* %-$40s"
+CHARS_TO_PRINT=38
+test:
+	cd tests && ./all.sh
+	@echo
+	@echo
+	@echo "Misc tests"
+	@echo "---------------------------------"
+	@echo -n "Checking spdx tags with reuse:            "
+	@-reuse lint > /dev/null && echo OK || echo "Reuse failed, but build is OK"
+
+
+loc:
+	@echo "Line counts"
+	@printf "Python:   %4s\n" `find . -name "*.py" | xargs wc -l | tail -1 | sed 's,total,,g'`
+	@printf "Bash:     %4s\n" `find . -name "*.sh" | xargs wc -l | tail -1 | sed 's,total,,g'`
+	@printf "Total:    %4s\n" `find . -name "*.py" -o -name "*.sh" | xargs wc -l | tail -1 | sed 's,total,,g'`


### PR DESCRIPTION
The Makefile is only for devel purposes so move it to not give the
impression that you can make && make install kind of things

Fixes #91 