### PR TITLE
Remove shell scripts from CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,6 +38,9 @@ jobs:
       run: python3 setup.py build
     - name: Install
       run: python3 setup.py install
+    - name: Test
+      run: |
+        JUNIT_REPORT=1 python3 -m pytest
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v2
       if: always() # always run even if the previous step fails

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,11 +38,6 @@ jobs:
       run: python3 setup.py build
     - name: Install
       run: python3 setup.py install
-    - name: Test
-      run: |
-        cd tests
-        JUNIT_REPORT=1 ./all.sh
-      shell: bash
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v2
       if: always() # always run even if the previous step fails


### PR DESCRIPTION
With this commit we remove the shell scripts from CI. Too many failures have been caused by these. Keeping the shell scripts for local use.