### PR TITLE
gitignore: add venv directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ tests/all.log
 .coverage
 
 tmp/*
+
+# python virtual environment related directory 
+.*venv


### PR DESCRIPTION
Add gitignore item to enable usage of python virtual environment.
This also enables vscode to access said venv directory and execute flict
in it.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>