### PR TITLE
workflow: fix venv activation

### DIFF
--- a/devel/workflow.sh
+++ b/devel/workflow.sh
@@ -38,7 +38,7 @@ start_environment()
 
 install_dependencies()
 {
-    source ${VENV_DIR}/bin/activate
+    . ${VENV_DIR}/bin/activate
 
     echo "Update python package feed ..."
     python3 -m pip install --upgrade pip
@@ -57,21 +57,21 @@ install_dependencies()
 
 build()
 {
-    source ${VENV_DIR}/bin/activate
+    . ${VENV_DIR}/bin/activate
     cd ${PROJECT_DIR}
     python3 setup.py build
 }
 
 install()
 {
-    source ${VENV_DIR}/bin/activate
+    . ${VENV_DIR}/bin/activate
     cd ${PROJECT_DIR}
     python3 setup.py install
 }
 
 run_tests()
 {
-    source ${VENV_DIR}/bin/activate
+    . ${VENV_DIR}/bin/activate
     cd ${PROJECT_DIR}/tests
     ./all.sh
 }


### PR DESCRIPTION
Fix venv activation by switching to the point operator instead of using
the 'source' command. Said command seems not to be present in a python
container and leads to 'source: not found'.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>