### PR TITLE
args-mock: Remove Deprecated Attributes

### DIFF
--- a/tests/args_mock.py
+++ b/tests/args_mock.py
@@ -9,17 +9,14 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class ArgsMock:
     debug_licenses : bool = False
-    enable_scancode : bool = False
     extended_licenses : bool = False
     license_expression : str = ''
-    license_group_file : str = flict_config.DEFAULT_GROUP_FILE
     licenses : str = None
     matrix_file : str = flict_config.DEFAULT_MATRIX_FILE
     no_relicense : str = False
     outbound_licenses : str = None
     output_format : str = 'JSON'
     relicense_file : str = flict_config.DEFAULT_RELICENSE_FILE
-    scancode_file : str = None
     translations_file : str = flict_config.DEFAULT_TRANSLATIONS_FILE
     verbose : str = False
     version : str = False


### PR DESCRIPTION
Remove attributes that were removed in PR #165 and therefore are no
longer needed in the args mock class.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>