### PR TITLE
requirements-dev: pin flake8 to < 4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 dataclasses >= 0.6.0, <2.0.0
+flake8 < 4.0.0
 flake8-fixme >=1.1.0, <3.0.0
 flake8-print >=4.0.0, <6.0.0
 pytest >=6.2.0, <8.0.0


### PR DESCRIPTION
due to incompatible changes in flake8.
This works around errors like

AttributeError: '_io.StringIO' object has no attribute 'buffer'
Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>