### PR TITLE
Python: End Support for Python 3.6

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setuptools.setup(
         "Natural Language :: English",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -56,5 +55,5 @@ setuptools.setup(
         "Programming Language :: Python :: 3",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    python_requires = '>=3.6',
+    python_requires = '>=3.7',
 )


### PR DESCRIPTION
Python 3.6 will reach its end of life by the 23rd of December in 2021.
See PEP-494 [1] for details. This will drop 3.6 from our CI pipeline and
from flicts list of supported versions.

[1] PEP-494: https://www.python.org/dev/peps/pep-0494/

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>