### PR TITLE
cli-json: Remove Obsolete Tests

### DIFF
--- a/tests/cli/cli-json.sh
+++ b/tests/cli/cli-json.sh
@@ -72,8 +72,6 @@ stdin_test()
 
 # list
 simple_test "list" 0 
-simple_test "list -g" 0
-simple_test "list -lg MIT" 0
 
 # verify
 simple_test "verify -pf ${FLICT_DIR}/example-data/europe-small.json" 0


### PR DESCRIPTION
Remove tests for groups and license groups that are no longer supported
as they were removed in #165.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>