### PR TITLE
Tests: Convert More Tests to Pytest

### DIFF
--- a/tests/cli/cli-json.sh
+++ b/tests/cli/cli-json.sh
@@ -81,18 +81,7 @@ stdin_test  "${FLICT_DIR}/example-data/europe-small.json" "verify -pf -" 0 "read
 stdin_test  "${FLICT_DIR}/example-data/europe-small.json" "verify -pf - -lcc" 0 "reading from stdin"
 stdin_test  "${FLICT_DIR}/example-data/europe-small.json" "verify -pf - -lpl" 0 "reading from stdin"
 
-# outbound-candidate
-simple_test "outbound-candidate MIT" 0 
-simple_test "outbound-candidate MIT and GPL-2.0-only" 0 
-
-# simplify
-simple_test "simplify MIT" 0 
-simple_test "simplify MIT and BSD" 0 
-simple_test "simplify MIT and GPL-2.0-only WITH Classpath-exception-2.0 and MIT" 0 
-
 # display-compatibility
-simple_test "display-compatibility MIT" 0 
 simple_test "display-compatibility MIT BSD GPL-2.0-only WITH Classpath-exception-2.0 " 0 
-
 
 end_test

--- a/tests/cli/cli-ret-code.sh
+++ b/tests/cli/cli-ret-code.sh
@@ -54,19 +54,4 @@ simple_test "verify -pf ${FLICT_DIR}/example-data/europe-small.json -lcc" 0
 simple_test "verify -pf ${FLICT_DIR}/example-data/europe-small.json -lpl" 0 
 simple_test "verify -pf ${FLICT_DIR}/example-data/europe-small-bad.json " 10
 
-# simplify
-simple_test "simplify MIT" 0 
-simple_test "simplify MIT and BSD ,,," 11
-
-# display-compatibility
-simple_test "display-compatibility MIT" 0 
-simple_test "display-compatibility MIT ..." 11
-
-# list
-## not possible to do wrong??
-
-# outbound-candidate
-simple_test "outbound-candidate MIT" 0 
-simple_test "outbound-candidate MIT ,,," 11
-
 end_test

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2022 Jens Erdmann
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+
+from flict.flictlib.return_codes import FlictError, ReturnCodes
+from flict.impl import FlictImpl
+from tests.args_mock import ArgsMock
+
+def test_exceptions():
+    with pytest.raises(FlictError) as _error:
+        args = ArgsMock(license_expression=['MIT and BSD ,,,'])
+        FlictImpl(args).simplify()
+
+    assert _error.value.args[0] == ReturnCodes.RET_INVALID_EXPRESSSION
+
+    with pytest.raises(FlictError) as _error:
+        args = ArgsMock(license_expression=['MIT ,,,'])
+        FlictImpl(args).suggest_outbound_candidate()
+
+    assert _error.value.args[0] == ReturnCodes.RET_INVALID_EXPRESSSION
+
+    with pytest.raises(FlictError) as _error:
+        args = ArgsMock(license_expression=['MIT ...'])
+        FlictImpl(args).display_compatibility()
+
+    assert _error.value.args[0] == ReturnCodes.RET_INVALID_EXPRESSSION

--- a/tests/test_outbounds.py
+++ b/tests/test_outbounds.py
@@ -16,6 +16,7 @@ def _test_expression(expression, result):
 def test_outbound():
     _test_expression(['MIT'], ['MIT'])
     _test_expression(['MIT and MIT'], ['MIT'])
+    _test_expression(['MIT and GPL-2.0-only'], ['GPL-2.0-only'])
     _test_expression(['MIT and MIT and BSD-3-Clause'], ['BSD-3-Clause', 'MIT'])
     _test_expression(['GPL-2.0-only and (MIT or BSD-3-Clause)'], ['GPL-2.0-only'])
     _test_expression(['GPL-2.0-only or (MIT and BSD-3-Clause)'], ['BSD-3-Clause', 'GPL-2.0-only', 'MIT'])

--- a/tests/test_simplified.py
+++ b/tests/test_simplified.py
@@ -22,3 +22,4 @@ def test_simplify():
     _test_expression(['GPL-2.0-only'], '{"original": "GPL-2.0-only", "simplified": "GPL-2.0-only"}')
     _test_expression(['GPL-2.0-or-later'], '{"original": "GPL-2.0-or-later", "simplified": "GPL-2.0-or-later"}')
     _test_expression(['GPL-2.0-or-later and MIT'], '{"original": "GPL-2.0-or-later and MIT", "simplified": "GPL-2.0-or-later AND MIT"}')
+    _test_expression(['MIT and GPL-2.0-only WITH Classpath-exception-2.0 and MIT'], '{"original": "MIT and GPL-2.0-only WITH Classpath-exception-2.0 and MIT", "simplified": "GPL-2.0-only WITH Classpath-exception-2.0 AND MIT"}')


### PR DESCRIPTION
Convert more tests to pytest by moving some tests into already existing test cases.
Also introduce a new test to check for exceptions to cover tests for return codes.