### PR TITLE
ci: run junit report publish on main repo only

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,7 +45,8 @@ jobs:
       shell: bash
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v2
-      if: always() # always run even if the previous step fails
+      # always run even if the previous step fails but only for the main repo
+      if: ${{ always() && github.event.pull_request.head.repo.full_name == github.repository }}
       with:
         report_paths: '**/TEST-*.xml'
     # Install a specific version of python-debian, as there is a pending upstream bug


### PR DESCRIPTION
as the needed credentials are not shared with forks

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>