### PR TITLE
test_compat: Move Test

### DIFF
--- a/tests/cli/cli-json.sh
+++ b/tests/cli/cli-json.sh
@@ -78,7 +78,4 @@ stdin_test  "${FLICT_DIR}/example-data/europe-small.json" "verify -pf -" 0 "read
 stdin_test  "${FLICT_DIR}/example-data/europe-small.json" "verify -pf - -lcc" 0 "reading from stdin"
 stdin_test  "${FLICT_DIR}/example-data/europe-small.json" "verify -pf - -lpl" 0 "reading from stdin"
 
-# display-compatibility
-simple_test "display-compatibility MIT BSD GPL-2.0-only WITH Classpath-exception-2.0 " 0 
-
 end_test

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -20,4 +20,5 @@ def test_complex_compat():
     jret = json.loads(ret)
 
     # this can not be a direct comparism as the result is in random order as of now
-    assert len(jret['compatibilities']) == 3
+    for lic in ['BSD-3-Clause', 'GPL-2.0-only WITH Classpath-exception-2.0', 'MIT']:
+        assert any(x['license'] == lic for x in jret['compatibilities'])

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import json
 import pytest
 
 from flict.impl import FlictImpl
@@ -11,3 +12,12 @@ def test_compat():
     args = ArgsMock(license_expression=['MIT'])
     ret = FlictImpl(args).display_compatibility()
     assert '{"compatibilities": [{"license": "MIT", "licenses": []}]}' == ret
+
+def test_complex_compat():
+    expr = ['MIT BSD GPL-2.0-only WITH Classpath-exception-2.0']    
+    args = ArgsMock(license_expression=expr)
+    ret = FlictImpl(args).display_compatibility()
+    jret = json.loads(ret)
+
+    # this can not be a direct comparism as the result is in random order as of now
+    assert len(jret['compatibilities']) == 3


### PR DESCRIPTION
Move test to display compatibility for multiple licensens from bash to pytest.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>