### PR TITLE
Report: Refactor Class 

### DIFF
--- a/flict/flictlib/format/json_format.py
+++ b/flict/flictlib/format/json_format.py
@@ -24,7 +24,7 @@ class JsonFormatter(FormatInterface):
         return json.dumps(license_list)
 
     def format_report(self, report):
-        return json.dumps(report.report())
+        return report.to_json()
 
     def format_license_combinations(self, project):
         return json.dumps({

--- a/flict/impl.py
+++ b/flict/impl.py
@@ -14,7 +14,7 @@ from flict.flictlib.format.factory import FormatFactory
 from flict.flictlib.license import LicenseHandler, decode_license_expression, encode_license_expression
 from flict.flictlib.policy import Policy
 from flict.flictlib.project import Project
-from flict.flictlib.report import Report, outbound_candidates
+from flict.flictlib.report import Report
 from flict.flictlib.return_codes import FlictError, ReturnCodes
 
 import json
@@ -30,8 +30,7 @@ class FlictImpl:
 
     def _empty_project_report(self, licenses):
         project = Project(None, self._license_handler, licenses)
-        report_object = Report(project, self._compatibility)
-        return report_object.report()
+        return Report(project, self._compatibility)
 
     def simplify(self):
         lic_str = " ".join(self._args.license_expression)
@@ -56,7 +55,7 @@ class FlictImpl:
 
         try:
             report = self._empty_project_report(lic_str)
-            candidates = report['compatibility_report']['compatibilities']['outbound_candidates']
+            candidates = report.outbound_candidates()
             return self._formatter.format_verified_license(lic_str, candidates)
         except:
             raise FlictError(ReturnCodes.RET_INVALID_EXPRESSSION,
@@ -129,7 +128,7 @@ class FlictImpl:
 
         try:
             _report = self._empty_project_report(lic_str)
-            _outbound_candidates = outbound_candidates(_report)
+            _outbound_candidates = _report.outbound_candidates()
             return self._formatter.format_outbound_license(_outbound_candidates)
         except:
             raise FlictError(ReturnCodes.RET_INVALID_EXPRESSSION,

--- a/flict/impl.py
+++ b/flict/impl.py
@@ -44,14 +44,12 @@ class FlictImpl:
                              f'Invalid expression to simplify: {self._args.license_expression}')
 
     def list_licenses(self):
-        formatted = ""
         if self._args.list_relicensing:
-            formatted = self._formatter.format_relicense_information(self._license_handler)
+            return self._formatter.format_relicense_information(self._license_handler)
         elif self._args.list_translation:
-            formatted = self._formatter.format_translation_information(self._license_handler)
+            return self._formatter.format_translation_information(self._license_handler)
         else:
-            formatted = self._formatter.format_support_licenses(self._compatibility)
-        return formatted
+            return self._formatter.format_support_licenses(self._compatibility)
 
     def _verify_license_expression(self):
         lic_str = " ".join(self._args.license_expression)
@@ -72,27 +70,22 @@ class FlictImpl:
         except:
             raise FlictError(ReturnCodes.RET_INVALID_PROJECT)
 
-        formatted = ""
         if self._args.list_project_licenses:
-            formatted = self._formatter.format_license_list(list(project.license_set()))
+            return self._formatter.format_license_list(list(project.license_set()))
         elif self._args.license_combination_count:
-            formatted = self._formatter.format_license_combinations(project)
+            return self._formatter.format_license_combinations(project)
         else:
             report = Report(project, self._compatibility)
-            formatted = self._formatter.format_report(report)
-
-        return formatted
+            return self._formatter.format_report(report)
 
     def verify(self):
-        formatted = ""
         if self._args.project_file:
-            formatted = self._verify_project_file()
+            return self._verify_project_file()
         elif self._args.license_expression:
-            formatted = self._verify_license_expression()
+            return self._verify_license_expression()
         else:
             raise FlictError(ReturnCodes.RET_MISSING_ARGS,
                              "Missing argument to the verify command")
-        return formatted
 
     def _read_compliance_report(self, report_file):
         with open(report_file) as fp:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -29,10 +29,8 @@ class ReportTest(unittest.TestCase):
         license_handler = LicenseHandler(TRANSLATION_FILE, RELICENSE_FILE, "")
         project = Project(TEST_DIR + "/example-data/imp.json", license_handler)
         compatibility = Compatibility(OSADL_MATRIX, False)
-        report_object = Report(project, compatibility)
-        report = report_object.report()
+        outbounds = Report(project, compatibility).outbound_candidates()
 
-        outbounds = report['licensing']['outbound_candidates']
         self.assertEqual(len(outbounds),2)
 
         self.assertTrue("GPL-2.0-only" in outbounds)


### PR DESCRIPTION
Refactor report class by removing report_map and all its invocations.
report_map lead to confusion about what the actual report is.
Make most methods private that were only used for initialization.
Make outbound_candidates a method. The anonymous function made not much
sense on its own. Replace all access to the inner dict for
outbound_candidates with the new method to hide internal details.
Rework to_json method to enable the refactored class to be serialized.