### PR TITLE
Dependabot: Add Simple Config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Dependabot Configuration File
+# For details see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+


### PR DESCRIPTION
Add simple configuration file to enable Dependabot service of GitHub to
update dependcies automatically.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>