### PR TITLE
Flake8: Update Ignore for Prints

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 dataclasses >= 0.6.0, <2.0.0
 flake8 < 4.0.0
 flake8-fixme >=1.1.0, <3.0.0
-flake8-print >=4.0.0, <6.0.0
+flake8-print >=5.0.0, <6.0.0
 pytest >=6.2.0, <8.0.0
 pytest-bandit >=0.6.0, <2.0
 pytest-cov >=0.6.0, <3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,8 @@ flake8-ignore =
     RST201
     RST203
     RST301
-    T001
     T101
+    T201
     W391
     W504
     WPS


### PR DESCRIPTION
Update flake8 ignore list. With version 5.0 of flake8-print the namespace got moved from T0* to T2*. To keep ignoring prints this has to be reflected in the ignore list. Hence the T001 > T201.
Also make flake8-print 5.0.0 the minimum requirement.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>