### PR TITLE
Dependabot: Exempt from Gitlint & Add GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
   gitlint:
       runs-on: ubuntu-latest
       name: GitLint
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
       steps:
         - name: Lint commits
           uses: aschbacd/gitlint-action@v1.0.1


### PR DESCRIPTION
Make dependabot be exempt from gitlint as it is not follwoing our rules in this regard by now.
Also add github actions to the scope of dependabot.

See commits for more details.