### PR TITLE
Fix #212 license preferences

### DIFF
--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -120,12 +120,12 @@ class Arbiter:
             'compatibility': compats
         }
 
-    def verify(self, project, licenses=None):
+    def verify(self, project, supplied_licenses=None):
         """Verifies a project's license to a list of outbounds and returns the
         compatibility between the liceses.
              Parameters:
                  project: the project (with its packages and their licenses) to check for compatibility
-                 licenses: the licenses to check the package's license against
+                 supplied_licenses: the licenses to check the package's license against
         """
 
         start_time = timestamp()
@@ -138,8 +138,10 @@ class Arbiter:
         for package in project['packages']:
             license_expression = Project.combined_work_license(package)
 
-            if licenses is None:
+            if supplied_licenses is None:
                 licenses = self.license_compatibility.licenses(license_expression)
+            else:
+                licenses = supplied_licenses
 
             all_licenses.update(licenses)
 

--- a/flict/flictlib/compatibility.py
+++ b/flict/flictlib/compatibility.py
@@ -276,7 +276,16 @@ class LicenseChooser:
             licenses - list of licenses to choose the most preferred from
         """
         index = None
+        # Loop through the supplied list of licenses, typically the
+        # set of all licenses in a project
         for lic in licenses:
+            # If the license is not found in the license preference list,
+            # raise an error
+            if lic not in self.licenses:
+                raise FlictError(ReturnCodes.RET_INVALID_LICENSE_PREFERENCE,
+                                 f'The supplied license preference list is incomplete. The license \"{lic}\" is missing from {self.licenses}.')
+
+            # identify the index and remember the lowest index (most preferred)
             lic_index = self.licenses.index(lic)
             if index is None or lic_index < index:
                 index = lic_index

--- a/flict/flictlib/return_codes.py
+++ b/flict/flictlib/return_codes.py
@@ -31,6 +31,7 @@ class ReturnCodes(Enum):
     RET_INVALID_EXPRESSSION = (11, "Invalid expression")
     RET_FILE_NOT_FOUND = (12, "File not found")
     RET_INVALID_ALIAS_FILE = (13, "Invalid alias file")
+    RET_INVALID_LICENSE_PREFERENCE = (13, "Invalid license preferences")
 
     @classmethod
     def get_help(cls, indent="  "):

--- a/tests/test_lic_pref.py
+++ b/tests/test_lic_pref.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2022 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+from flict.flictlib.arbiter import Arbiter
+from flict.flictlib.project.reader import ProjectReaderFactory
+from flict.flictlib.return_codes import FlictError, ReturnCodes
+
+class Zlib:
+    """
+    class providing a verification of zlib (SBoM)
+    """
+    def __init__(self, licenses_preferences=None):
+        self._arbiter = Arbiter(licenses_preferences=licenses_preferences)
+        self._reader = ProjectReaderFactory.get_projectreader(project_format="spdx")
+        self._project = self._reader.read_project("example-data/zlib-1.2.11.spdx.json")
+        self._verification = self._arbiter.verify(self._project)
+        
+    def verification(self):
+        return self._verification
+
+def _generic_test(verification):
+    # just to make sure verfication seems to be OK
+    # before we check details
+    assert verification['project_name'] 
+    assert verification['packages']
+
+    for package in verification['packages']:
+        assert package['compatibility']
+    
+
+def test_zlib_verification():
+    """
+    Simple verification of the zlib verification
+    """
+    zlib = Zlib()
+    verification = zlib.verification()
+
+    _generic_test(verification)
+
+    
+def test_zlib_pref_list():
+    """
+    Verify that an incomplete list of preferences raises a flict error, rather than a generic Python oneq
+    """
+    
+    # Create an incomplete license pref list
+    lic_prefs = {
+        "license_preferences": [
+            "curl", "MIT"
+        ]
+    }
+
+    # Use the incomplete license pref list, when verifying zlib
+    # Make sure an error is raised
+    with pytest.raises(FlictError) as _error:
+        zlib = Zlib(lic_prefs)
+        verification = zlib.verification()
+
+    assert _error.value.args[0] == ReturnCodes.RET_INVALID_LICENSE_PREFERENCE
+    
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_lic_pref.py
+++ b/tests/test_lic_pref.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: 2022 Henrik Sandklef
 #
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/test_lic_pref.py
+++ b/tests/test_lic_pref.py
@@ -59,6 +59,3 @@ def test_zlib_pref_list():
         verification = zlib.verification()
 
     assert _error.value.args[0] == ReturnCodes.RET_INVALID_LICENSE_PREFERENCE
-    
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
With these commits we fix #212 

Instead of:
`ValueError: 'Zlib' is not in list` 

the user will get :
`ERROR:flict:The supplied license preference list is incomplete. The license "Zlib" is missing from ['curl', 'MIT'].
`
