### PR TITLE
Reader: Refactor Flatten Package Tree

### DIFF
--- a/flict/flictlib/project/reader.py
+++ b/flict/flictlib/project/reader.py
@@ -202,20 +202,11 @@ class SPDXJsonProjectReader(ProjectReader):
     def _flatten_package_tree(self, packages):
         package_dict = {}
 
-        for pkg in packages.items():
-            #print(pkg[]
-            _package = pkg[1]
-            name = _package['name']
-            version = _package['version']
-            package = {
-                'name': name,
-                'version': version,
-                'license': _package['license'],
-                'description': _package['description'],
-            }
-            package_dict.update({name + "--" + version: package})
-            for dep in _package['dependencies']:
-                flat_dep = self._flatten_package_tree(dep)
-                package_dict.update(flat_dep)
+        for _package in packages.values():
+            package_dict.update(
+                {f"{_package['name']}--{_package['version']}": _package}
+            )
+            for dep in _package["dependencies"]:
+                package_dict.update(self._flatten_package_tree(dep))
 
         return package_dict


### PR DESCRIPTION
Refactor flatten package tree function by removing the recreation of package objects. Also use values instead of items as there is no use of the keys anyways.

Signed-off-by: Jens Erdmann <jens.erdmann@web.de>