### PR TITLE
Readme and small feature

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -30,9 +30,12 @@ $ flict display-compatibility BSD-3-Clause MIT GPL-2.0-only
 {"compatibilities": [{"license": "MIT", "licenses": [{"license": "BSD-3-Clause", "compatible_right": "true", "compatible_left": "true"}, {"license": "GPL-2.0-only", "compatible_right": "true", "compatible_left": "false"}]}, {"license": "BSD-3-Clause", "licenses": [{"license": "MIT", "compatible_right": "true", "compatible_left": "true"}, {"license": "GPL-2.0-only", "compatible_right": "true", "compatible_left": "false"}]}, {"license": "GPL-2.0-only", "licenses": [{"license": "MIT", "compatible_right": "false", "compatible_left": "true"}, {"license": "BSD-3-Clause", "compatible_right": "false", "compatible_left": "true"}]}]}
 ```
 
+As a result, you can see a list of compatibilities in form: which license is analysed, and if it is compatible with all others specified.
+Given that, one can see that MIT and GPL-2.0-only are compatible only one-way.
+
 ## Create graph over compatibility
 
-Instead of a text based representation (as above) you can instead create a graphical representation using `dot` format. 
+Instead of a text based representation (as above) you can instead create a graphical representation using `dot` format.
 
 ```shell
 $ flict -of dot display-compatibility BSD-3-Clause MIT GPL-2.0-only > compat.dot

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -20,6 +20,7 @@ The following software are needed to use flict:
 - run `git clone https://github.com/vinland-technology/flict`
 - *optional*: checkout the revision you like to install
 - run `cd flict`
+- run `pip3 install -r requirements.txt`
 - run `pip3 install .` _(might require sudo/root/admin rights)_
 
 ## Install development version
@@ -27,13 +28,14 @@ The following software are needed to use flict:
 - run `git clone https://github.com/vinland-technology/flict`
 - *optional*: checkout the revision you like to install
 - run `cd flict`
+- run `pip3 install -r requirements-dev.txt`
 - run `pip3 install -e .[dev]` _(might require sudo/root/admin rights)_
 
 ### Non-root installation
 
 In case you don't have root access on your machine you need add `--user` to all the `pip3` calls - e.g. `pip3 install --user -e .[dev]`.
 
-**NOTE: On __Debian__ system that is the default behavior**
+**NOTE: On __Debian-based__ systems that is the default behavior**
 
 # Docker image
 

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ flict can:
 
 * suggest candidate outbound licenses
 
-* simplify license expressions 
+* simplify license expressions
 
-* display, in misc format, compatibilies between licenses 
+* display, in misc format, compatibilies between licenses
 
 * ~~check outbound licenses against a policy (policy as supplied by the user)~~ (automatic now)
 
 flict supports:
 
-* 87 licenses (```flict -of text list```) 
+* 87 licenses (```flict -of text list```)
 
 * common non SPDX ways to write licenses (e.g GPLv2 -> GPL-2.0-only), see "License alias defininitions" in [SETTINGS](SETTINGS.md)
 
@@ -115,7 +115,7 @@ formats (e.g. html, pdf). Partially supported.
 
 ### Text
 
-Partially supported. 
+Partially supported.
 
 ## User specific configuration
 
@@ -135,7 +135,7 @@ Either create a json file at `~/.flict.cfg` or at a path defined by environment 
 ```json
 {
     "license_matrix-file": "/my/very/own/osadl-matrix.csv",
-    "output-format": "text",
+    "output-format": "text"
 }
 ```
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -8,7 +8,7 @@ You can tweak flict by providing:
 
 * [_Alias__](#alias) - alias for "non standard" spelled licenes (e.g. 'BSD3 -> BSD-3-Clause')
 
-# Configuration and runtime files 
+# Configuration and runtime files
 
 <a name="alias"></a>
 ## License alias defininitions
@@ -18,7 +18,7 @@ files is intended to translate from "non SPDX" to SPDX. You can
 provide a list of definitions for this tool to decide how these
 "incorrectly spelled" licenses should be interpreted.
 
-By default flict uses the following alias file: [var/alias.json](var/alias.json)
+By default flict uses the following alias file: [var/alias.json](flict/var/alias.json)
 
 Example:
 
@@ -33,7 +33,7 @@ Example:
 }
 ```
 
-As with previous example you can for now skip the meta section. A translation definition is specified using:
+You can for now skip the meta section, which is present in example. A translation definition is specified using:
 
 ```alias``` - the expression we want to translate to a "proper" license, e.gg GPLv2+
 
@@ -51,7 +51,7 @@ Example:
 ```
 {
     "licenses_denied": ["MIT"]
-}                  
+}
 ```
 
 If you store this in a file, `denied-list.json`, you can use it like this:
@@ -70,7 +70,7 @@ In cases where a choice between licenses can be made flict chose the
 most preferred license. By default flict counts how many other
 licenses each license is compatible with. The more licenses a license
 is compatible with the more preferred it will be. If two licenses have
-the same number of compatibilities alpabetical order will be used to
+the same number of compatibilities, alpabetical order will be used to
 chose license.
 
 If you want to provide your own ordered list of license preference, you do this like this:
@@ -83,7 +83,7 @@ Example:
         "curl", "MIT"
     ]
 
-}                  
+}
 ```
 
 If you store this in a file, `license-preferences.json`, you can use it with the `-lpf` option.
@@ -94,7 +94,7 @@ If you store this in a file, `license-preferences.json`, you can use it with the
 If you want to extend or override the license database with new
 licenses you can do this with a custom database.
 
-Let's say you want to add support for a new license, called 'ABC'. You need to add how this new license is compatible with all other in both ways. 
+Let's say you want to add support for a new license, called 'ABC'. You need to add how this new license is compatible with all other in both ways.
 
 Adding information how existing licenses ('0BSD', 'AFL-2.0' and so on), can use 'ABC':
 ```
@@ -135,6 +135,7 @@ These should be placed inside `osadl_additional_licenses` like this:
 *Note: the above is an incomplete example. All licenses supported by
  the OSADL matrix need to be defined in relation to the new license,
  not only '0BSD' and 'AFL-2.0'.*
+ This file is further called `additional_matrix.json`.
 
 To apply the new license db and store the result in `merged-matrix.csv`:
 

--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -134,7 +134,7 @@ These should be placed inside `osadl_additional_licenses` like this:
 
 *Note: the above is an incomplete example. All licenses supported by
  the OSADL matrix need to be defined in relation to the new license,
- not only '0BSD' and 'AFL-2.0'.*
+ not only '0BSD' and 'AFL-2.0'.*. If they are NOT defined - 'Unknown' compatibility will be assumed.
  This file is further called `additional_matrix.json`.
 
 To apply the new license db and store the result in `merged-matrix.csv`:

--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -235,6 +235,7 @@ def simplify(args):
 
 
 def _merge_licenses(args):
+    file_sanity_check(args.license_file)
     ret = FlictImpl(args).merge_license_db()
     flict_print(args, ret)
 
@@ -250,6 +251,10 @@ def verify(args):
 
 
 def display_compatibility(args):
+    on_error = "Expected at least two licenses for checking compatibility"
+    on_error_code = ReturnCodes.RET_MISSING_ARGS
+    if len(args.license_expression) == 1:
+        flict_exit(on_error_code, on_error)
     ret = FlictImpl(args).display_compatibility()
     flict_print(args, ret)
 
@@ -260,19 +265,18 @@ def suggest_outbound_candidate(args):
 
 
 def policy_report(args):
-    on_error = "Provided file {fname} was not found."
-    on_error_code = ReturnCodes.RET_FILE_NOT_FOUND
-    try:
-        open(args.report_file).close()
-    except (FileNotFoundError, PermissionError):
-        flict_exit(on_error_code, on_error.format(fname=args.report_file))
-    try:
-        open(args.policy_file).close()
-    except (FileNotFoundError, PermissionError):
-        flict_exit(on_error_code, on_error.format(fname=args.policy_file))
+    file_sanity_check(args.report_file)
+    file_sanity_check(args.policy_file)
     ret = FlictImpl(args).policy_report()
     flict_print(args, ret)
 
+def file_sanity_check(fname):
+    on_error = "Provided file {fname} was not found, or cannot be read."
+    on_error_code = ReturnCodes.RET_FILE_NOT_FOUND
+    try:
+        open(fname).close()
+    except (FileNotFoundError, PermissionError):
+        flict_exit(on_error_code, on_error.format(fname=fname))
 
 def main():
     args = parse()

--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -270,6 +270,7 @@ def policy_report(args):
     ret = FlictImpl(args).policy_report()
     flict_print(args, ret)
 
+
 def file_sanity_check(fname):
     on_error = "Provided file {fname} was not found, or cannot be read."
     on_error_code = ReturnCodes.RET_FILE_NOT_FOUND
@@ -277,6 +278,7 @@ def file_sanity_check(fname):
         open(fname).close()
     except (FileNotFoundError, PermissionError):
         flict_exit(on_error_code, on_error.format(fname=fname))
+
 
 def main():
     args = parse()

--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -183,10 +183,6 @@ def parse():
         'display-compatibility', help='display license compatibility graphically')
     parser_d.set_defaults(which="display-compatibility",
                           func=display_compatibility)
-    parser_d.add_argument('--graph', '-g', type=str,
-                          help='create graph representation')
-    parser_d.add_argument('--table', '-t', type=str,
-                          help='create table representation')
     parser_d.add_argument('license_expression', type=str, nargs='+',
                           help='license expression to display compatibility for')
 

--- a/flict/flictlib/compatibility.py
+++ b/flict/flictlib/compatibility.py
@@ -211,7 +211,6 @@ class OsadlCompatibility(Compatibility):
         for line in _csv:
             if len(line) < 3:
                 continue
-            #print(line)
         return _csv
 
     def _create_matrix_csv_data(self, file_name):


### PR DESCRIPTION
cleanup: trailing whitespace, old-unused arguments, README
main: check if files exist and are accessible
compatibility: improve error message and extend_licenses process