### PR TITLE
Add project dir to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     long_description_content_type = "text/markdown",
     license_files = ('LICENSE',),
     url = "https://github.com/vinland-technology/flict",
-    packages = ['flict', 'flict.flictlib', 'flict.flictlib.format'],
+    packages = ['flict', 'flict.flictlib', 'flict.flictlib.format', 'flict.flictlib.project'],
     entry_points = {
         "console_scripts": [
             "flict = flict.__main__:main",


### PR DESCRIPTION
`flict.flictlib.project` is not part of the packages list in setup.py

this commit fixes that 