### PR TITLE
tests: switch unittest to pytest

### DIFF
--- a/tests/test_license.py
+++ b/tests/test_license.py
@@ -1,58 +1,56 @@
-#!/usr/bin/env python3
-
 # SPDX-FileCopyrightText: 2022 Henrik Sandklef
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import unittest
+import pytest
 
 from flict.flictlib.return_codes import FlictError
-from flict.flictlib.return_codes import ReturnCodes
 
 from flict.flictlib.license_parser import LicenseParserFactory
 from flict.flictlib.license_parser import PrettyLicenseParser
 
 
-class TestLicenseParser(unittest.TestCase):
-
-    def _parse_and_get_simple_license(self, parser, expr):
-        return parser.parse_license([expr])['license']['name']
-    
-    def test_license_parser_parse_license(self):
-        parser = LicenseParserFactory.get_parser()
-        
-        self.assertEqual(self._parse_and_get_simple_license(parser, "MIT"), "MIT")
-        self.assertEqual(self._parse_and_get_simple_license(parser, "X11"), "X11")
-
-        self.assertEqual(self._parse_and_get_simple_license(parser, "GPL-2.0-only WITH Classpath-exception-2.0"), "GPL-2.0-only WITH Classpath-exception-2.0")
+@pytest.fixture(autouse=True)
+def parser():
+    one_and_only_blessed_parser = LicenseParserFactory.get_parser()
+    assert (one_and_only_blessed_parser.utils)
+    yield one_and_only_blessed_parser
 
 
-        mit_and_x11 = parser.parse_license(["MIT AND X11"])
-        self.assertEqual(mit_and_x11['license']['type'], "operator")
-        self.assertEqual(mit_and_x11['license']['name'], "AND")
-
-        operands = mit_and_x11['license']['operands']
-
-        self.assertTrue(operands[0]['name'] == "MIT" and operands[1]['name'] == "X11" or
-                            operands[1]['name'] == "MIT" and operands[0]['name'] == "X11")
-
-        with self.assertRaises(FlictError):
-            parser.parse_license("This is not a list")
-
-        with self.assertRaises(FlictError):
-            parser.parse_license([])
-
-        with self.assertRaises(FlictError):
-            parser.parse_license([""])
-
-    def test_licenses(self):
-        parser = LicenseParserFactory.get_parser()
-        license_list = parser.licenses("MIT and BSD-3-Clause OR X11 AND MIT OR BSD-3-Clause")
-        print("license_list: " + str(license_list))
-            
+@pytest.fixture
+def parse_single_license(parser):
+    yield parser.parse_license
 
 
-if __name__ == '__main__':
-    unittest.main()
-        
-        
+@pytest.fixture
+def parse_simple(parse_single_license, lic_expr):
+    yield parse_single_license([lic_expr])['license']
+
+
+@pytest.mark.parametrize('lic_expr', ['MIT', "GPL-2.0-only WITH Classpath-exception-2.0"])
+def test_simple_license_result_contain_expected_keys_single_license(parse_simple, lic_expr):
+    assert isinstance(parse_simple, dict)
+    keys, vals = parse_simple.items()
+    assert all((set(keys) == {"license", "type"}, set(vals) == {lic_expr, "name"}))
+    assert parse_simple["name"] == lic_expr
+
+
+@pytest.mark.parametrize('lic_expr', ['MIT AND X11', ])
+def test_simple_license_contain_expected_keys_two_licenses(parse_simple, lic_expr):
+    assert (isinstance(parse_simple, dict))
+    p = parse_simple
+    assert p["name"] == "AND"
+    assert len(p["operands"]) == 2
+    assert p["type"] == "operator"
+    assert all((lic["type"] == "license" for lic in p["operands"]))
+    assert all((lic["name"] in ("MIT", "X11") for lic in p["operands"]))
+
+
+def test_licenses_without_duplicates(parser):
+    license_list = parser.licenses("MIT and BSD-3-Clause OR X11 AND MIT OR BSD-3-Clause")
+    assert {'X11', 'BSD-3-Clause', 'MIT'} == set(license_list)
+
+
+def test_licenses_with_duplicates(parser):
+    license_list = parser.licenses("MIT and BSD-3-Clause AND MIT OR X11 AND MIT OR BSD-3-Clause")
+    assert {'X11', 'BSD-3-Clause', 'MIT'} == set(license_list)


### PR DESCRIPTION
two tests are commented out, it seems
that there is no easy way to test if fixture
raises intended error. I've tested a couple
of not-so-easy-hackery-ways but to no avail.

Signed-off-by: Krzysztof Królczyk <Krzysztof.Krolczyk@o2.pl>