### PR TITLE
flict-config: safety fallback for HOME

### DIFF
--- a/flict/flictlib/flict_config.py
+++ b/flict/flictlib/flict_config.py
@@ -17,7 +17,7 @@ from osadl_matrix import OSADL_MATRIX
 def read_user_config():
     for path in [
         os.environ.get('FLICT_USERCONFIG'),
-        os.path.join(os.environ.get('HOME'), '.flict.cfg'),
+        os.path.join(os.environ.get('HOME', '/does/not/exist'), '.flict.cfg'),
     ]:
         try:
             with open(path) as i:


### PR DESCRIPTION
if HOME is not set (and there might be even obscure Unix setups that do that), the app crashes at startup.
Fix that by providing a non-existing dir.
For users that need to have flict-config without HOME dir being present still FLICT_USERCONFIG is available. That one can be used to provide a full qualified path of a cfg file to be used

Relates to #251

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>