### PR TITLE
Adapt to osadl matrix

### DIFF
--- a/SETTINGS.md
+++ b/SETTINGS.md
@@ -137,21 +137,23 @@ These should be placed inside `osadl_additional_licenses` like this:
  not only '0BSD' and 'AFL-2.0'.*. If they are NOT defined - 'Unknown' compatibility will be assumed.
  This file is further called `additional_matrix.json`.
 
-To apply the new license db and store the result in `merged-matrix.csv`:
+To apply the new license db and store the result in `merged-matrix.json`:
 
 ```
-flict merge -lf additional_matrix.json > merged-matrix.csv
+flict merge -lf additional_matrix.json > merged-matrix.json
 
 ```
 
 To list the supported licenses, with the added licenses:
 
 ```
-flict -lmf merged-matrix.csv list
+flict -lmf merged-matrix.json list
 ```
 
 To use this merged license database when for example veryfing a license:
 
 ```
-flict -lmf merged-matrix.csv verify -il 0BSD -ol ABC
+flict -lmf merged-matrix.json verify -il 0BSD -ol ABC
 ```
+
+*Note: Previously flict created csv output when merging. If you still want csv output, use `-of csv`*

--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -209,8 +209,8 @@ class Arbiter:
         """Check compatbilitiy between supplied licenses"""
         return self.license_compatibility.check_compatibilities(licenses, check_all)
 
-    def extend_license_db(self, file_name, format="JSON"):
-        return self.license_compatibility.extend_license_db(file_name, format)
+    def extend_license_db(self, file_name, oformat="JSON"):
+        return self.license_compatibility.extend_license_db(file_name, oformat)
 
     def simplify_license(self, expr):
         return self.license_compatibility.simplify_license(expr)

--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -209,8 +209,8 @@ class Arbiter:
         """Check compatbilitiy between supplied licenses"""
         return self.license_compatibility.check_compatibilities(licenses, check_all)
 
-    def extend_license_db(self, file_name):
-        return self.license_compatibility.extend_license_db(file_name)
+    def extend_license_db(self, file_name, format="JSON"):
+        return self.license_compatibility.extend_license_db(file_name, format)
 
     def simplify_license(self, expr):
         return self.license_compatibility.simplify_license(expr)

--- a/flict/flictlib/compatibility.py
+++ b/flict/flictlib/compatibility.py
@@ -255,13 +255,13 @@ class OsadlCompatibility(Compatibility):
             osadl_data = json.load(fp)
 
         for key, value in additional_data.items():
-            if not key in osadl_data:
-                osadl_data[key]={}
+            if key not in osadl_data:
+                osadl_data[key] = {}
             osadl_data[key].update(value)
-    
+
         return json.dumps(osadl_data, indent=4)
 
-    def extend_license_db(self, file_name, format="JSON"):
+    def extend_license_db(self, file_name, oformat="JSON"):
         """Extends the current license db with licese db provided in file_name.
 
         Parameters:
@@ -270,7 +270,7 @@ class OsadlCompatibility(Compatibility):
         See SETTINGS.md for more information about format and
         requirements for a custom database.
         """
-        if format.lower() == "csv":
+        if oformat.lower() == "csv":
             return self._create_matrix_csv_data(file_name)
 
         return self._create_matrix_json_data(file_name)

--- a/flict/flictlib/flict_config.py
+++ b/flict/flictlib/flict_config.py
@@ -11,7 +11,7 @@
 import json
 import os
 
-from osadl_matrix import OSADL_MATRIX
+from osadl_matrix import OSADL_MATRIX_JSON
 
 
 def read_user_config():
@@ -38,5 +38,5 @@ VAR_DIR = os.path.join(SCRIPT_DIR, "var")
 BUILTIN_ALIAS_FILE = os.path.join(VAR_DIR, "alias.json")
 DEFAULT_FLICT_ALIAS_FILE = os.path.join(VAR_DIR, BUILTIN_ALIAS_FILE)
 
-DEFAULT_MATRIX_FILE = _userconfig.get('matrix-file', OSADL_MATRIX)
+DEFAULT_MATRIX_FILE = _userconfig.get('matrix-file', OSADL_MATRIX_JSON)
 DEFAULT_OUTPUT_FORMAT = _userconfig.get('output-format', "JSON")

--- a/flict/flictlib/lic_comp.py
+++ b/flict/flictlib/lic_comp.py
@@ -188,8 +188,8 @@ class LicenseCompatibilty:
     def check_compatibilities(self, licenses, check_all=False):
         return self.compatibility.check_compatibilities(licenses, check_all)
 
-    def extend_license_db(self, file_name):
-        return self.compatibility.extend_license_db(file_name)
+    def extend_license_db(self, file_name, format="JSON"):
+        return self.compatibility.extend_license_db(file_name, format)
 
     def simplify_license(self, expr):
         return self.license.simplify_license(expr)

--- a/flict/flictlib/lic_comp.py
+++ b/flict/flictlib/lic_comp.py
@@ -188,8 +188,8 @@ class LicenseCompatibilty:
     def check_compatibilities(self, licenses, check_all=False):
         return self.compatibility.check_compatibilities(licenses, check_all)
 
-    def extend_license_db(self, file_name, format="JSON"):
-        return self.compatibility.extend_license_db(file_name, format)
+    def extend_license_db(self, file_name, oformat="JSON"):
+        return self.compatibility.extend_license_db(file_name, oformat)
 
     def simplify_license(self, expr):
         return self.license.simplify_license(expr)

--- a/flict/impl.py
+++ b/flict/impl.py
@@ -3,7 +3,7 @@
 # flict - FOSS License Compatibility Tool
 #
 # SPDX-FileCopyrightText: 2021 Jens Erdmann
-# SPDX-FileCopyrightText: 2022 Henrik Sandklef
+# SPDX-FileCopyrightText: 2023 Henrik Sandklef
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -27,7 +27,7 @@ class FlictImpl:
         self._formatter = FormatterFactory.formatter(args.output_format)
 
     def merge_license_db(self):
-        return self.arbiter.extend_license_db(self._args.license_file)
+        return self.arbiter.extend_license_db(self._args.license_file, format=self._args.output_format)
 
     def display_compatibility(self):
         inter_compats = self.arbiter.check_compatibilities(self._args.license_expression)


### PR DESCRIPTION
With these commits flict is adapted to osadl_matrix now using JSON as default format.
Merging (`merge`) now defaults to JSON format.