### PR TITLE
Fix outbound candidate and merge

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -58,3 +58,20 @@ License: GPL-3.0-or-later
 Files: .bumpversion.cfg
 Copyright: 2022 Konrad Weihmann @priv-kweihmann
 License: GPL-3.0-or-later
+
+Files: tests/complete-lic-ext.json
+Copyright: 2023 Henrik Sandklef <hesa@sandklef.com>
+License: GPL-3.0-or-later
+
+Files: tests/incomplete-lic-ext.json
+Copyright: 2023 Henrik Sandklef <hesa@sandklef.com>
+License: GPL-3.0-or-later
+
+Files: tests/mini-matrix.json
+Copyright: 2023 Henrik Sandklef <hesa@sandklef.com>
+License: GPL-3.0-or-later
+
+Files: tmp-test-data.json
+Copyright: 2023 Henrik Sandklef <hesa@sandklef.com>
+License: GPL-3.0-or-later
+

--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -175,6 +175,7 @@ def parse():
     merge_parser = subparsers.add_parser('merge', help="Merge additional licenses with OSADL's matrix. Will output to store in a file, for use with --license-matrix-file")
     merge_parser.set_defaults(which="merge", func=_merge_licenses)
     merge_parser.add_argument('--license-file', '-lf', type=str, dest='license_file', help='License file (JSON) to merge', default=None)
+    merge_parser.add_argument('--default-no', '-dn', action='store_true', dest='default_no', help='If no compatibility can be found in the additional matrix, "No" compatibility is assumed. Works only for JSON input matrix', default=False)
 
     # display-compatibility
     parser_d = subparsers.add_parser(

--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -209,8 +209,8 @@ class Arbiter:
         """Check compatbilitiy between supplied licenses"""
         return self.license_compatibility.check_compatibilities(licenses, check_all)
 
-    def extend_license_db(self, file_name, oformat="JSON"):
-        return self.license_compatibility.extend_license_db(file_name, oformat)
+    def extend_license_db(self, file_name, oformat="JSON", default_no=False):
+        return self.license_compatibility.extend_license_db(file_name, oformat, default_no)
 
     def simplify_license(self, expr):
         return self.license_compatibility.simplify_license(expr)

--- a/flict/flictlib/compatibility.py
+++ b/flict/flictlib/compatibility.py
@@ -110,13 +110,11 @@ class Compatibility:
             for lic_b in licenses:
 
                 comp_left = self.check_compat(lic_a, lic_b)['compatibility']
-                #print(f'comp: {self.check_compat(lic_a, lic_b)}')
                 comp_right = self.check_compat(lic_b, lic_a)['compatibility']
 
                 if CompatibilityStatus.LICENSE_COMPATIBILITY_UNKNOWN.value in (comp_left, comp_right):
                     supported = self.supported_licenses()
                     lic_bad = ",".join({lic for lic in (lic_a, lic_b) if lic not in supported})
-                    #print(f'comp_left: {comp_left}   comp_right: {comp_right}')
                     raise FlictError(ReturnCodes.RET_INVALID_EXPRESSSION,
                                      f'License expression "{lic_bad}" is not supported.')
 
@@ -167,10 +165,10 @@ class OsadlCompatibility(Compatibility):
         inbound = self.alias.replace_aliases(_inbound)
 
         supported = osadl_matrix.supported_licenses()
-        if not outbound in supported:
+        if outbound not in supported:
             raise FlictError(ReturnCodes.RET_INVALID_EXPRESSSION,
                              f'Compatibility between \"{outbound}\" and \"{inbound}\" could not be determined, since \"{outbound}\" is an unknown license')
-        if not inbound in supported:
+        if inbound not in supported:
             raise FlictError(ReturnCodes.RET_INVALID_EXPRESSSION,
                              f'Compatibility between \"{outbound}\" and \"{inbound}\" could not be determined, since \"{inbound}\" is an unknown license')
 
@@ -278,7 +276,7 @@ class OsadlCompatibility(Compatibility):
         for outer_key in all_keys:
             if outer_key.startswith("timeformat") or outer_key.startswith("timestamp"):
                 continue
-            
+ 
             # Make sure all inner keys are present in outer key
             for inner_key in osadl_data[outer_key]:
                 if inner_key not in all_keys:
@@ -298,11 +296,10 @@ class OsadlCompatibility(Compatibility):
                         else:
                             report.append((f'{key} not present in {inner_key}'))
 
-
         if len(report) != 0:
             raise FlictError(ReturnCodes.RET_INVALID_MATRIX,
                              f'Merging {self.license_db} with {file_name} failed with the following errors: {report}')
-            
+
         if default_no:
             osadl_data = fixed_matrix
         return json.dumps(osadl_data, indent=4)

--- a/flict/flictlib/compatibility.py
+++ b/flict/flictlib/compatibility.py
@@ -276,7 +276,7 @@ class OsadlCompatibility(Compatibility):
         for outer_key in all_keys:
             if outer_key.startswith("timeformat") or outer_key.startswith("timestamp"):
                 continue
- 
+
             # Make sure all inner keys are present in outer key
             for inner_key in osadl_data[outer_key]:
                 if inner_key not in all_keys:
@@ -290,7 +290,6 @@ class OsadlCompatibility(Compatibility):
                         report.append((f'{inner_key} not present'))
                     elif key not in osadl_data[inner_key].keys():
                         if default_no:
-                            #print((f'Set {key} in {inner_key} to No'))
                             fixed_matrix[inner_key] = fixed_matrix[inner_key].copy()
                             fixed_matrix[inner_key][key] = "No"
                         else:

--- a/flict/flictlib/lic_comp.py
+++ b/flict/flictlib/lic_comp.py
@@ -105,7 +105,6 @@ class LicenseCompatibilty:
         elif self.license.is_operator(expr):
             raise FlictError(ReturnCodes.RET_INTERNAL_ERROR,
                              f'Internal error. Cannot transform {expr} to a license expression')
-            
 
     def _inbounds_outbound_check_operator(self, outbound, expr):
         compat_summary = None
@@ -131,8 +130,7 @@ class LicenseCompatibilty:
                 compat_summary = self._update_compat(op, compat_summary, compat_tag == CompatibilityStatus.LICENSE_COMPATIBILITY_COMPATIBLE.value)
             elif compat_tag == "Undefined":
                 raise FlictError(ReturnCodes.RET_INVALID_EXPRESSSION,
-                                 f'Undefined license')
-            
+                                 'Undefined license')
 
             # are licenses allowed or denied for this expression
             allowed = compat['allowed']
@@ -180,7 +178,6 @@ class LicenseCompatibilty:
                              f"Could not parse one of the expression: {outbound}, {expr}")
 
     def _update_compat(self, op, current, new):
-#        print(f'_update_compat(self, {op}, {current}, {new})')
         if current is None:
             updated = new
         elif op == LICENSE_COMPATIBILITY_AND:

--- a/flict/flictlib/return_codes.py
+++ b/flict/flictlib/return_codes.py
@@ -30,6 +30,7 @@ class ReturnCodes(Enum):
     RET_FILE_NOT_FOUND = (12, "File not found")
     RET_INVALID_ALIAS_FILE = (13, "Invalid alias file")
     RET_INVALID_LICENSE_PREFERENCE = (13, "Invalid license preferences")
+    RET_INVALID_MATRIX = (14, "Invalid matrix or matrix extension")
 
     @classmethod
     def get_help(cls, indent="  "):

--- a/flict/impl.py
+++ b/flict/impl.py
@@ -27,7 +27,7 @@ class FlictImpl:
         self._formatter = FormatterFactory.formatter(args.output_format)
 
     def merge_license_db(self):
-        return self.arbiter.extend_license_db(self._args.license_file, format=self._args.output_format)
+        return self.arbiter.extend_license_db(self._args.license_file, oformat=self._args.output_format, default_no=self._args.default_no)
 
     def display_compatibility(self):
         inter_compats = self.arbiter.check_compatibilities(self._args.license_expression)
@@ -46,16 +46,18 @@ class FlictImpl:
         try:
             for outbound in licenses:
                 compats = self.arbiter.inbounds_outbound_check(outbound, self._args.license_expression)
-                compatible = (compats['compatibility'] == "Yes")
-                if compatible:
+                compat_status = compats['compatibility']
+                if compat_status == "Yes":
                     outbounds.append(outbound)
+                elif compat_status == "No":
+                    pass
 
             outbounds.sort()
             return self._formatter.format_outbound_license(outbounds)
 
-        except BaseException:
+        except Exception as e:
             raise FlictError(ReturnCodes.RET_INVALID_EXPRESSSION,
-                             f'Invalid license expression: {self._args.license_expression}')
+                             f'Invalid license expression: {self._args.license_expression}. Original cause: {e}')
 
     def list_licenses(self):
         licenses = list(self.arbiter.supported_licenses())

--- a/tests/args_mock.py
+++ b/tests/args_mock.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class ArgsMock:
     debug_licenses : bool = False
+    default_no : bool = False
     extended_licenses : bool = False
     license_combination_count : bool = False
     license_expression : str = ''

--- a/tests/complete-lic-ext.json
+++ b/tests/complete-lic-ext.json
@@ -1,0 +1,19 @@
+{
+    "osadl_additional_licenses" : {
+	"BSD-3-Clause": {
+	    "Proprietary": "No"
+	},
+	"Dummy": {
+	    "Proprietary": "No"
+	},
+	"GPL-2.0-or-later": {
+	    "Proprietary": "No"
+	},
+	"Proprietary": {
+	    "BSD-3-Clause": "Same",
+	    "Dummy": "Yes",
+	    "GPL-2.0-or-later": "No",
+	    "Proprietary": "Same"
+	}
+    }
+}

--- a/tests/incomplete-lic-ext.json
+++ b/tests/incomplete-lic-ext.json
@@ -1,0 +1,10 @@
+{
+    "osadl_additional_licenses" : {
+        "Apache-2.0":  {
+            "Proprietary": "?"
+        },
+        "Proprietary":  {
+            "BSD-3-Clause": "Yes"
+        }
+    }
+}

--- a/tests/mini-matrix.json
+++ b/tests/mini-matrix.json
@@ -1,0 +1,17 @@
+{
+    "BSD-3-Clause": {
+	"BSD-3-Clause": "Same",
+	"Dummy": "Yes",
+	"GPL-2.0-or-later": "No"
+    },
+    "Dummy": {
+	"BSD-3-Clause": "No",
+	"Dummy": "Same",
+	"GPL-2.0-or-later": "No"
+    },
+    "GPL-2.0-or-later": {
+	"BSD-3-Clause": "Yes",
+	"Dummy": "Yes",
+	"GPL-2.0-or-later": "Same"
+    }
+}

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2022 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import pytest
+
+from flict.impl import FlictImpl
+from tests.args_mock import ArgsMock
+from flict.flictlib.return_codes import FlictError, ReturnCodes
+
+matrix_file = "tests/mini-matrix.json"
+complete_addition_file = "tests/complete-lic-ext.json"
+incomplete_addition_file = "tests/incomplete-lic-ext.json"
+tmp_test_file = "tmp-test-data.json"
+
+def _test_expression(orig_matrix, additional_matrix):
+    args = ArgsMock(license_matrix_file=orig_matrix, license_file=additional_matrix)
+    return FlictImpl(args).merge_license_db()
+
+def test_incomplete_additional():
+    with pytest.raises(FlictError) as _error:
+        _test_expression(matrix_file, incomplete_addition_file)
+    
+def test_complete_additional():
+    text =_test_expression(matrix_file, complete_addition_file)
+    db = json.loads(text)
+    assert len(db) == 4
+    
+@pytest.fixture(scope='session')
+def test_complete_creation():
+    text =_test_expression(matrix_file, complete_addition_file)
+    db = json.loads(text)
+    with open(tmp_test_file, 'w') as fp:
+        json.dump(db, fp, indent=4)
+
+def _check_compat(expr):
+    args = ArgsMock(license_matrix_file=tmp_test_file, license_expression=[expr])
+    impl = FlictImpl(args)
+    candidate = impl.suggest_outbound_candidate()
+    return candidate
+        
+@pytest.mark.usefixtures('test_complete_creation')
+def test_compat():
+    _check_compat("Dummy and BSD-3-Clause")
+    
+@pytest.mark.usefixtures('test_complete_creation')
+def test_compat2():
+    _check_compat("Dummy and BSD-3-Clause")
+    
+    
+    

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -14,17 +14,22 @@ complete_addition_file = "tests/complete-lic-ext.json"
 incomplete_addition_file = "tests/incomplete-lic-ext.json"
 tmp_test_file = "tmp-test-data.json"
 
-def _test_expression(orig_matrix, additional_matrix):
-    args = ArgsMock(license_matrix_file=orig_matrix, license_file=additional_matrix)
+def _test_expression(orig_matrix, additional_matrix, default_no=False):
+    args = ArgsMock(license_matrix_file=orig_matrix, license_file=additional_matrix, default_no=default_no)
     return FlictImpl(args).merge_license_db()
 
 def test_incomplete_additional():
     with pytest.raises(FlictError) as _error:
         _test_expression(matrix_file, incomplete_addition_file)
     
+def test_incomplete_additional_fix():
+    _test_expression(matrix_file, incomplete_addition_file, default_no=True)
+    
 def test_complete_additional():
     text =_test_expression(matrix_file, complete_addition_file)
     db = json.loads(text)
+    db.pop("timestamp", None)
+    db.pop("timeformat", None)
     assert len(db) == 4
     
 @pytest.fixture(scope='session')

--- a/tests/test_outbounds.py
+++ b/tests/test_outbounds.py
@@ -67,5 +67,5 @@ def test_outbound_16():
 
 def test_outbound_17():
     _test_expression(['(GPL-2.0-only or MPL-2.0) and (Apache-2.0 or MPL-2.0) and (X11 or BSD-3-Clause) and LGPL-2.1-only'],
-                    ['GPL-2.0-only', 'MPL-2.0', 'Apache-2.0'])
+                    ['GPL-2.0-only', 'LGPL-2.1-only'])
 

--- a/tests/test_outbounds.py
+++ b/tests/test_outbounds.py
@@ -13,21 +13,59 @@ def _test_expression(expression, result):
     ret = FlictImpl(args).suggest_outbound_candidate()
     assert result == json.loads(ret)
 
-def test_outbound():
+def test_outbound_1():
     _test_expression(['MIT'], ['MIT'])
+
+def test_outbound_2():
     _test_expression(['MIT and MIT'], ['MIT'])
+
+def test_outbound_3():
     _test_expression(['MIT and GPL-2.0-only'], ['GPL-2.0-only'])
+
+def test_outbound_4():
     _test_expression(['MIT and MIT and BSD-3-Clause'], ['BSD-3-Clause', 'MIT'])
+
+def test_outbound_5():
     _test_expression(['GPL-2.0-only and (MIT or BSD-3-Clause)'], ['GPL-2.0-only'])
+
+def test_outbound_6():
     _test_expression(['GPL-2.0-only or (MIT and BSD-3-Clause)'], ['BSD-3-Clause', 'GPL-2.0-only', 'MIT'])
+
+def test_outbound_7():
     _test_expression(['GPL-2.0-only and (Apache-2.0 or MIT)'], ['GPL-2.0-only'])
+
+def test_outbound_8():
     _test_expression(['GPL-2.0-only or (Apache-2.0 and MIT)'], ['Apache-2.0', 'GPL-2.0-only', 'MIT'])
+
+def test_outbound_9():
     _test_expression(['GPL-2.0-only and Apache-2.0'], [])
+
+def test_outbound_10():
     _test_expression(['GPL-2.0-only and Apache-2.0 and MPL-2.0'], [])
+
+def test_outbound_11():
     _test_expression(['GPL-2.0-only and MPL-2.0'], ['GPL-2.0-only'])
+
+def test_outbound_12():
     _test_expression(['GPL-2.0-only and MPL-2.0'], ['GPL-2.0-only'])
+
+def test_outbound_13():
     _test_expression(['GPL-2.0-only and (MPL-2.0 or Apache-2.0) and BSD-3-Clause'],
                     ['GPL-2.0-only'])
+
+def test_outbound_14():
     _test_expression(['(GPL-2.0-only or MPL-2.0) and (Apache-2.0 or BSD-3-Clause)'],
                     ['GPL-2.0-only', 'MPL-2.0'])
+
+def test_outbound_15():
+    _test_expression(['(GPL-2.0-only or MPL-2.0) and (Apache-2.0 or BSD-3-Clause or MIT or X11) and MIT'],
+                    ['GPL-2.0-only', 'MPL-2.0'])
+
+def test_outbound_16():
+    _test_expression(['(GPL-2.0-only or MPL-2.0) and (Apache-2.0 or BSD-3-Clause or MIT or X11) and GPL-3.0-or-later'],
+                    ['GPL-3.0-or-later'])
+
+def test_outbound_17():
+    _test_expression(['(GPL-2.0-only or MPL-2.0) and (Apache-2.0 or MPL-2.0) and (X11 or BSD-3-Clause) and LGPL-2.1-only'],
+                    ['GPL-2.0-only', 'MPL-2.0', 'Apache-2.0'])
 


### PR DESCRIPTION
This PR fixes:

* "Unknown" and "Check dependency" compatibilities were causing incorrect outbound candidates. 

* Previously only the OSADL matrix could be added to, now any JSON input matrix (`-lmf orig.json`) could be extended (`merge -lf additional.json`)