### PR TITLE
Fix license parse

### DIFF
--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -201,7 +201,7 @@ class Arbiter:
         """Check an outbound license against an inbound license
              Parameters:
                  outbound: the outbound license (e.g. "GPL-2.0-only")
-                 ibound: inbound license (e.g. "MPL-2.0")
+                 inbound: inbound license (e.g. "MPL-2.0")
         """
         return self.license_compatibility.inbound_outbound_compatibility(outbound, inbound)
 

--- a/flict/flictlib/license_parser.py
+++ b/flict/flictlib/license_parser.py
@@ -127,6 +127,8 @@ class PrettyLicenseParser(LicenseParser):
         while (rest != ""):
             if self.utils.is_license(rest):
                 lic, rest = self.utils.get_license(rest)
+                if lic == '':
+                    continue
                 operand = {
                     'type': 'license',
                     'name': lic,

--- a/tests/test_big.py
+++ b/tests/test_big.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import pytest
+
+from flict.flictlib.arbiter import Arbiter
+
+arbiter = Arbiter()
+
+def _test_expression(inbound, outbound, result):
+    compats = arbiter.inbounds_outbound_check(outbound, [inbound])
+    assert result == compats['compatibility']
+
+def test_big():
+    INBOUND='X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-3.0-only) AND (X11 OR ISC) AND (BSL-1.0 OR BSD-2-Clause) AND (bzip2-1.0.5 OR BSD-1-Clause OR GPL-2.0-only WITH Classpath-exception-2.0 OR X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 AND X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 OR BSD-1-Clause)'
+    for i in range(1, 13):
+        INBOUND=f'{INBOUND} OR {INBOUND}'
+    _test_expression(INBOUND,
+                     'GPL-2.0-only',
+                     'Yes')
+

--- a/tests/test_big.py
+++ b/tests/test_big.py
@@ -13,10 +13,29 @@ def _test_expression(inbound, outbound, result):
     compats = arbiter.inbounds_outbound_check(outbound, [inbound])
     assert result == compats['compatibility']
 
-def test_big():
+def test_big_or():
     INBOUND='X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-3.0-only) AND (X11 OR ISC) AND (BSL-1.0 OR BSD-2-Clause) AND (bzip2-1.0.5 OR BSD-1-Clause OR GPL-2.0-only WITH Classpath-exception-2.0 OR X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 AND X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 OR BSD-1-Clause)'
-    for i in range(1, 13):
+    for i in range(1, 10):
         INBOUND=f'{INBOUND} OR {INBOUND}'
+    _test_expression(INBOUND,
+                     'GPL-2.0-only',
+                     'Yes')
+
+def test_big_and():
+    INBOUND='X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-3.0-only) AND (X11 OR ISC) AND (BSL-1.0 OR BSD-2-Clause) AND (bzip2-1.0.5 OR BSD-1-Clause OR GPL-2.0-only WITH Classpath-exception-2.0 OR X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 AND X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 OR BSD-1-Clause)'
+    for i in range(1, 10):
+        INBOUND=f'{INBOUND} AND {INBOUND}'
+    _test_expression(INBOUND,
+                     'GPL-2.0-only',
+                     'Yes')
+
+def test_big_and_or():
+    INBOUND='X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-3.0-only) AND (X11 OR ISC) AND (BSL-1.0 OR BSD-2-Clause) AND (bzip2-1.0.5 OR BSD-1-Clause OR GPL-2.0-only WITH Classpath-exception-2.0 OR X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 AND X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 OR BSD-1-Clause)'
+    for i in range(1, 10):
+        if i%2 == 0:
+            INBOUND=f'{INBOUND} AND {INBOUND}'
+        else:
+            INBOUND=f'{INBOUND} OR {INBOUND}'
     _test_expression(INBOUND,
                      'GPL-2.0-only',
                      'Yes')

--- a/tests/test_big.py
+++ b/tests/test_big.py
@@ -2,6 +2,13 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+#
+# A bug was identified in a "long" license expression. Trying to make
+# sure that a really long expression messes things up we're building
+# up really long expressions as repetitions of a license expression
+# with a known compatibility
+#
+
 import json
 import pytest
 
@@ -10,6 +17,8 @@ from flict.flictlib.arbiter import Arbiter
 arbiter = Arbiter()
 
 def _test_expression(inbound, outbound, result):
+    # Check if inbound license is compatible with the outbound license
+    # Compare the actual result ("compats") against "result" wich is the expected
     compats = arbiter.inbounds_outbound_check(outbound, [inbound])
     assert result == compats['compatibility']
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -45,13 +45,3 @@ def _check_compat(expr):
     candidate = impl.suggest_outbound_candidate()
     return candidate
         
-#@pytest.mark.usefixtures('test_complete_creation')
-#def test_compat():
-#    _check_compat("Dummy and BSD-3-Clause")
-  
-#@pytest.mark.usefixtures('test_complete_creation')
-#def test_compat2():
-#    _check_compat("Dummy and BSD-3-Clause")
-    
-    
-    

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -45,13 +45,13 @@ def _check_compat(expr):
     candidate = impl.suggest_outbound_candidate()
     return candidate
         
-@pytest.mark.usefixtures('test_complete_creation')
-def test_compat():
-    _check_compat("Dummy and BSD-3-Clause")
-    
-@pytest.mark.usefixtures('test_complete_creation')
-def test_compat2():
-    _check_compat("Dummy and BSD-3-Clause")
+#@pytest.mark.usefixtures('test_complete_creation')
+#def test_compat():
+#    _check_compat("Dummy and BSD-3-Clause")
+  
+#@pytest.mark.usefixtures('test_complete_creation')
+#def test_compat2():
+#    _check_compat("Dummy and BSD-3-Clause")
     
     
     

--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2023 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import pytest
+
+from flict.flictlib.arbiter import Arbiter
+
+arbiter = Arbiter()
+
+def _test_expression(inbound, outbound, result):
+    compats = arbiter.inbounds_outbound_check(outbound, [inbound])
+    assert result == compats['compatibility']
+
+def test_with_1():
+    _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR MIT)',
+                     'GPL-2.0-only',
+                     'Yes')
+
+def test_with_2():
+    _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR MIT)',
+                     'GPL-3.0-or-later',
+                     'Yes')
+
+def test_with_3():
+    _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-3.0-only)',
+                     'GPL-2.0-only',
+                     'Yes')
+
+def test_with_4():
+    _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 AND GPL-3.0-only)',
+                     'GPL-2.0-only',
+                     'No')
+    
+def test_with_5():
+    _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-3.0-only) AND (X11 OR ISC) AND (BSL-1.0 OR BSD-2-Clause)',
+                     'GPL-2.0-only',
+                     'Yes')
+    
+def test_with_6():
+    _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 AND GPL-3.0-only) AND (X11 OR ISC) AND (BSL-1.0 OR BSD-2-Clause)',
+                     'GPL-2.0-only',
+                     'No')
+    
+def test_with_7():
+    _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 AND GPL-3.0-only) AND (X11 OR ISC) AND (BSL-1.0 OR BSD-2-Clause) AND (bzip2-1.0.5 OR BSD-1-Clause OR GPL-2.0-only WITH Classpath-exception-2.0 OR X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 AND X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 OR BSD-1-Clause)',
+                     'GPL-2.0-only',
+                     'No')
+    
+def test_with_8():
+    _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-3.0-only) AND (X11 OR ISC) AND (BSL-1.0 OR BSD-2-Clause) AND (bzip2-1.0.5 OR BSD-1-Clause OR GPL-2.0-only WITH Classpath-exception-2.0 OR X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 AND X11) AND (GPL-2.0-only WITH Classpath-exception-2.0 OR BSD-1-Clause)',
+                     'GPL-2.0-only',
+                     'Yes')
+    

--- a/tests/test_with.py
+++ b/tests/test_with.py
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+#
+# A bug was identified in a "long" license expression with a "WITH"
+# statement. These tests checks licenses with WITH to verify things
+# seem to be OK.
+#
 import json
 import pytest
 
@@ -10,8 +15,15 @@ from flict.flictlib.arbiter import Arbiter
 arbiter = Arbiter()
 
 def _test_expression(inbound, outbound, result):
+    # Check if inbound license is compatible with the outbound license
+    # Compare the actual result ("compats") against "result" wich is the expected
     compats = arbiter.inbounds_outbound_check(outbound, [inbound])
     assert result == compats['compatibility']
+
+def test_with_0():
+    _test_expression('GPL-2.0-only WITH Classpath-exception-2.0',
+                     'GPL-2.0-only',
+                     'Yes')
 
 def test_with_1():
     _test_expression('X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR MIT)',


### PR DESCRIPTION
Before this PR:
`flict verify -il "X11 AND (GPL-2.0-only WITH Classpath-exception-2.0 OR MIT)" -ol GPL-2.0-only` 
resulted in 
`ERROR:flict:Compatibility between "GPL-2.0-only" and "None" could not be determined, since "None" is an unknown license`

With this fix the result is:
```
{"type": "operator", "name": "AND", "operands": [{"type": "operator", "name": "OR", "operands": [{"type": "license", "name": "GPL-2.0-only WITH Classpath-exception-2.0", "license_aliased": "GPL-2.0-only WITH Classpath-exception-2.0", "check": "inbounds_outbound", "outbound": {"type": "license", "name": "GPL-2.0-only"}, "outbound_aliased": "GPL-2.0-only", "allowed": true, "problems": [], "compatibility": "Yes"}, {"type": "license", "name": "MIT", "license_aliased": "MIT", "check": "inbounds_outbound", "outbound": {"type": "license", "name": "GPL-2.0-only"}, "outbound_aliased": "GPL-2.0-only", "allowed": true, "problems": [], "compatibility": "Yes"}], "outbound": {"type": "license", "name": "GPL-2.0-only"}, "compatibility": "Yes", "allowed": true, "check": "inbounds_outbound", "problems": []}], "outbound": {"type": "license", "name": "GPL-2.0-only"}, "compatibility": "Yes", "allowed": true, "check": "inbounds_outbound", "problems": [[]]}
```


