### PR TITLE
Allow unknown licenses

### DIFF
--- a/flict/flictlib/lic_comp.py
+++ b/flict/flictlib/lic_comp.py
@@ -119,11 +119,13 @@ class LicenseCompatibilty:
             # get compatibility_tag between the operand and the outbound
             # and calculate and store the summarized compatibility
             compat = self._inbounds_outbound_check(outbound, operand)
+            if compat['problems']:
+                problem_summary += compat['problems']
             compat_tag = compat[COMPATIBILITY_TAG]
             if compat_tag == "Yes" or compat_tag == "No":
                 compat_summary = self._update_compat(op, compat_summary, compat_tag == CompatibilityStatus.LICENSE_COMPATIBILITY_COMPATIBLE.value)
             elif compat_tag == "Unknown":
-                problems.append(f'Unknown license compatibility between outbound \'{outbound["name"]}\' and {self.__internal_expr_to_str(operand)}')
+                problems.append(f'Unknown license compatibility between outbound \'{outbound["name"]}\' and inbound \'{self.__internal_expr_to_str(operand)}\'')
                 compat_summary = self._update_compat(op, compat_summary, compat_tag == CompatibilityStatus.LICENSE_COMPATIBILITY_COMPATIBLE.value)
             elif compat_tag.startswith("Check"):
                 problems.append(f'Manually check license compatibility between {outbound}')
@@ -138,7 +140,8 @@ class LicenseCompatibilty:
             operand['allowed'] = allowed
             operand[COMPATIBILITY_TAG] = compat[COMPATIBILITY_TAG]
             operand["problems"] = problems
-            problem_summary.append(problems)
+            if problems:
+                problem_summary += problems
 
         # store outbound to make for easier reading of result
         expr['outbound'] = outbound
@@ -146,7 +149,6 @@ class LicenseCompatibilty:
         expr["allowed"] = allowed_summary
         expr['check'] = 'inbounds_outbound'
         expr["problems"] = problem_summary
-
         return expr
 
     def _inbounds_outbound_check_license(self, outbound, expr):

--- a/tests/test_unknown.py
+++ b/tests/test_unknown.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2023 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+
+from flict.flictlib.arbiter import Arbiter
+from flict.flictlib.return_codes import FlictError
+from flict.flictlib.compatibility import CompatibilityFactory
+from flict.flictlib.compatibility import CompatibilityStatus
+
+
+#
+# Test singe licenses against each other
+#
+
+def test_compat_known():
+    compatbility = CompatibilityFactory.get_compatibility()
+    compat = compatbility.check_compat("MIT", "MIT")
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_COMPATIBLE.value == compat['compatibility']
+
+def test_compat_unknown_inbound():
+    compatbility = CompatibilityFactory.get_compatibility()
+    compat = compatbility.check_compat("MIT", "NONESUCHNLICENSE")
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_UNKNOWN.value == compat['compatibility']
+
+def test_compat_unknown_outbound():
+    compatbility = CompatibilityFactory.get_compatibility()
+    with pytest.raises(FlictError) as _error:
+        compat = compatbility.check_compat("NONESUCHNLICENSE", "MIT")
+
+#
+# Test license expressions against outbound
+#
+
+def test_verify_i_o_check_known():
+    arbiter = Arbiter()
+    compats = arbiter.inbounds_outbound_check("MIT", ["MIT"])
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_COMPATIBLE.value == compats['compatibility']
+
+def test_verify_i_o_check_unknown_inbound():
+    arbiter = Arbiter()
+    compats = arbiter.inbounds_outbound_check("MIT", ["NONESUCHNLICENSE"])
+    # unknown license gives unknown compatibility
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_UNKNOWN.value == compats['compatibility']
+
+def test_verify_i_o_check_mix_inbound1or():
+    arbiter = Arbiter()
+    compats = arbiter.inbounds_outbound_check("MIT", ["NONESUCHNLICENSE OR X11"])
+    # MIT is compatible with X11, so the result is compatible even though NONESUCHNLICENSE is not compatible
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_COMPATIBLE.value == compats['compatibility']
+
+def test_verify_i_o_check_mix_inbound1and():
+    arbiter = Arbiter()
+    compats = arbiter.inbounds_outbound_check("MIT", ["NONESUCHNLICENSE AND X11"])
+    # MIT is compatible with X11 but not NONESUCHNLICENSE, so incompatible
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_INCOMPATIBLE.value == compats['compatibility']
+
+def test_verify_i_o_check_mix_inbound2or():
+    arbiter = Arbiter()
+    compats = arbiter.inbounds_outbound_check("MIT", ["NONESUCHNLICENSE OR NOTTHISEITHER"])
+    # Both inbound are unknown, so incompatible
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_INCOMPATIBLE.value == compats['compatibility']
+
+def test_verify_i_o_check_mix_inbound2and():
+    arbiter = Arbiter()
+    compats = arbiter.inbounds_outbound_check("MIT", ["NONESUCHNLICENSE AND NOTTHISEITHER"])
+    # Both inbound are unknown, so incompatible
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_INCOMPATIBLE.value == compats['compatibility']
+
+def test_verify_i_o_check_mix_inbound3or():
+    arbiter = Arbiter()
+    compats = arbiter.inbounds_outbound_check("MIT", ["NONESUCHNLICENSE OR NOTTHISEITHER OR MIT"])
+    # MIT is compatible with X11 so even thouth not the other two are not compatible, the whole thing is compatible
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_COMPATIBLE.value == compats['compatibility']
+                    
+def test_verify_i_o_check_mix_inbound3and():
+    arbiter = Arbiter()
+    compats = arbiter.inbounds_outbound_check("MIT", ["NONESUCHNLICENSE AND NOTTHISEITHER AND MIT"])
+    # MIT is compatible with X11 but not the other two, so incompatible
+    assert CompatibilityStatus.LICENSE_COMPATIBILITY_INCOMPATIBLE.value == compats['compatibility']
+
+def test_verify_i_o_check_unknown_outbound():
+    arbiter = Arbiter()
+    # an unknown outbound is illegal and will raise a FlictError
+    with pytest.raises(FlictError) as _error:
+        compats = arbiter.inbounds_outbound_check("NONESUCHNLICENSE", ["MIT"])
+
+def test_verify_i_o_check_unknown_all():
+    arbiter = Arbiter()
+    # an unknown outbound is illegal and will raise a FlictError
+    with pytest.raises(FlictError) as _error:
+        compats = arbiter.inbounds_outbound_check("NONESUCHNLICENSE", ["NOLICENSE"])


### PR DESCRIPTION
**Background** 

Here is a licensing scenario

* outbound: `GPL-2.0-only`
* inbound: `MIT OR NONESUCH`

Even though `NONESUCH` is unknown we can still find a way to reach license compatibility by choosing `MIT` as inbound (which  can be used by `GPL-2.0-only`).

The current behavior is to exit with an status code indicating an error (see example below).

**Changes**
With these commits the behavior is changed to return the license compatibility status (and not exit with an error code) if an unknown inbound license is provided.

_Note:_ An unknown outbound license will still give an error.

**Examples**

**_Current behavior_**
```
$ flict  -of text --verbose verify --inbound "MIT OR NONESUCH" --outbound "GPL-2.0-only" ; echo $?
ERROR:flict:Compatibility between "GPL-2.0-only" and "NONESUCH" could not be determined, since "NONESUCH" is an unknown license
11
```

**_New behavior_**
```
$ flict  -of text --verbose verify --inbound "MIT OR NONESUCH" --outbound "GPL-2.0-only" ; echo $?
Yes
0

$ flict  -of text --verbose verify --inbound "NONESUCH" --outbound "GPL-2.0-only" ; echo $?
No
0
```





