### PR TITLE
Fix denied licenses

### DIFF
--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -155,22 +155,33 @@ class Arbiter:
             # Get the alias for all outbound licenses
             outbound_licenses_aliased = [self.license_compatibility.replace_aliases(lic) for lic in outbound_licenses]
 
+            allowed_outbound_licenses = []
+            allowed_outbound_licenses_aliased = []
+
+            for idx in range(0, len(outbound_licenses_aliased)):
+                # if the license[idx] is allowed (not denied)
+                if self.license_compatibility.license.license_allowed(outbound_licenses_aliased[idx]):
+                    allowed_outbound_licenses.append(outbound_licenses[idx])
+                    allowed_outbound_licenses_aliased.append(outbound_licenses_aliased[idx])
+
             # Identify single outbound (chosen) license (from the aliased outbound licenses)
-            chosen_alias = self.license_compatibility.choose_license(outbound_licenses_aliased)
+            chosen_alias = self.license_compatibility.choose_license(allowed_outbound_licenses_aliased)
             if chosen_alias is None:
                 chosen_license = None
             else:
                 # Find the index of the aliased license
                 # and use that to identify the original (not aliased) license
-                index = outbound_licenses_aliased.index(chosen_alias)
-                chosen_license = outbound_licenses[index]
+                index = allowed_outbound_licenses_aliased.index(chosen_alias)
+                chosen_license = allowed_outbound_licenses[index]
 
             package_info.update({
                 'dependencies': dep_infos,
                 'outbound_licenses': outbound_licenses,
                 'outbound_licenses_aliased': outbound_licenses_aliased,
-                'outbound_license': chosen_license,
-                'outbound_license_aliased': chosen_alias,
+                'allowed_outbound_licenses': allowed_outbound_licenses,
+                'allowed_outbound_licenses_aliased': allowed_outbound_licenses_aliased,
+                'allowed_outbound_license': chosen_license,
+                'allowed_outbound_license_aliased': chosen_alias,
             })
             package_infos.append(package_info)
 

--- a/tests/test_denied.py
+++ b/tests/test_denied.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2024 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+#
+# test passing a list of denied licenses to arbiter. None of these should not be returned
+# as allowed outbound licenses after a verification of a project (freetype)
+#
+
+import json
+import pytest
+
+from flict.flictlib.arbiter import Arbiter
+from flict.flictlib.return_codes import FlictError, ReturnCodes
+from flict.flictlib.project.reader import ProjectReaderFactory
+
+reader = ProjectReaderFactory.get_projectreader(project_format="spdx", project_dirs=["example-data"])
+freetype = reader.read_project("example-data/freetype-2.9.spdx.json")
+
+def test_freetype_verification():
+    # normal verification
+    arbiter = Arbiter()
+    verification = arbiter.verify(freetype)
+    allowed_outbounds = verification['packages'][0]['allowed_outbound_licenses_aliased']
+    expected_allowed = ['FTL', 'Libpng', 'Zlib', 'GPL-2.0-or-later']
+    expected_allowed.sort()
+    allowed_outbounds.sort()
+    assert allowed_outbounds == expected_allowed
+
+def test_freetype_verification_denied1():
+    # verification with denied licenses: 'Zlib' 
+    arbiter = Arbiter(denied_licenses=['Zlib'])
+    verification = arbiter.verify(freetype)
+    allowed_outbounds = verification['packages'][0]['allowed_outbound_licenses_aliased']
+    expected_allowed = ['FTL', 'Libpng', 'GPL-2.0-or-later']
+    expected_allowed.sort()
+    allowed_outbounds.sort()
+    assert allowed_outbounds == expected_allowed
+
+def test_freetype_verification_denied2():
+    # verification with denied licenses: 'FTL', 'Zlib' 
+    arbiter = Arbiter(denied_licenses=['FTL', 'Zlib'])
+    verification = arbiter.verify(freetype)
+    allowed_outbounds = verification['packages'][0]['allowed_outbound_licenses_aliased']
+    expected_allowed = ['Libpng', 'GPL-2.0-or-later']
+    expected_allowed.sort()
+    allowed_outbounds.sort()
+    assert allowed_outbounds == expected_allowed
+
+    


### PR DESCRIPTION
User can pass licenses to be denied. These should not show up in the list of compatible (and allowed) licenses.

**Current situation**
Verifying the example `example-data/freetype-2.9.spdx.json` will return four suggested outbound licenses (compatible with the inbound licenses):

```
$ flict verify --sbom-dir example-data/ --sbom example-data/freetype-2.9.spdx.json  | jq .packages[0].outbound_licenses_aliased
[
  "GPL-2.0-or-later",
  "Zlib",
  "Libpng",
  "FTL"
]
```

**Bug**
Before the commits in this PR, the option `--licenses-denied-file` was discarded.

**Solution**
With these commits you can do:

```
$ flict --licenses-denied-file denied-licenses.json  verify --sbom-dir example-data/ --sbom example-data/freetype-2.9.spdx.json  | jq .packages[0].allowed_outbound_licenses_aliased
[
  "Zlib",
  "GPL-2.0-or-later"
]
```

**Impact on report**
Two new fields have been added:
* `allowed_outbound_licenses_aliased` - list of all allowed and compatible licenses
* `allowed_outbound_license_aliased `- the most preferred allowed and compatible license




