### PR TITLE
Clear wordings on license in doc and code, dual license expansion optional

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
 
-# Display Simplify license expression
+# Simplify license expression
 
 To simplify the expression `MIT and BSD-3-Clause and MIT`, type:
 
@@ -19,6 +19,45 @@ and if you want the result in `text` format:
 ```shell
 $ flict -of text simplify MIT and BSD-3-Clause and MIT
 BSD-3-Clause AND MIT
+```
+
+# Normalize a license expression
+
+To normalize the expression `BSD3 and x11-keith-packard and GPL-2.0-or-later`, type:
+
+```shell
+$ flict -of text simplify BSD3 and x11-keith-packard and GPL-2.0-or-later
+BSD-3-Clause AND HPND AND (GPL-2.0-only OR GPL-3.0-only)
+```
+Replacements:
+
+* `BSD3` is an alias for `BSD-3-Clause`
+
+* `x11-keith-packard`has the same compatibility as `HPND`
+
+* `GPL-2.0-or-later` is replaced by `(GPL-2.0-only OR GPL-3.0-only)` since it can be seen as a dual license
+
+*Note: if you do not want the dual license to be expanded, use the option `--no-relicense`*
+
+# Verify an outbound license expression against an inbound license expression
+
+To verify that the outbound license expression, `GPL-2.0-only AND BSD-3-Clause` is compatible with the inbound license expression `HPND or X11 and BSD3`
+
+```shell
+$ flict verify -il HPND or X11 and BSD3 -ol GPL-2.0-only AND BSD-3-Clause
+ERROR:flict:Unknown or undefined licenses identified: Unknown license compatibility between outbound 'GPL-2.0-only' and inbound 'HPND'
+```
+
+Flict exit with an error if any problems were identified.
+
+
+# Force verify an outbound license expression against an inbound license expression
+
+To verify, and continue even if problems were found, that the above license expressions we can use the `--ignore-problems` option.
+
+```shell
+$ flict --ignore-problems verify -il HPND or X11 and BSD3 -ol GPL-2.0-only AND BSD-3-Clause
+{"original_outbound": "GPL-2.0-only AND BSD-3-Clause", "outbound": "GPL-2.0-only AND BSD-3-Clause", "inbound": "HPND OR (X11 AND BSD-3-Clause)", "original_inbound": "HPND or X11 and BSD3", "result": {"outbound_licenses": ["GPL-2.0-only"], "allowed_outbound_licenses": ["GPL-2.0-only"], "outbound_license": "GPL-2.0-only", "problems": ["Unknown license compatibility between outbound 'GPL-2.0-only' and inbound 'HPND'"]}}
 ```
 
 # Check compatibility between licenses
@@ -94,14 +133,10 @@ This creates a report in JSON
 To get the suggested outbound licenses from the report (using `jq`), type:
 
 ```shell
-$ jq '.licensing.outbound_candidates' europe-report.json
+$ jq '.packages[].allowed_outbound_licenses' europe-report.json 
 [
-  "Apache-2.0",
-  "BSD-3-Clause",
   "GPL-2.0-only",
-  "GPL-3.0-only",
-  "MIT",
-  "MPL-1.1"
+  "GPL-3.0-only"
 ]
 ```
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -48,12 +48,12 @@ $ flict verify -il HPND or X11 and BSD3 -ol GPL-2.0-only AND BSD-3-Clause
 ERROR:flict:Unknown or undefined licenses identified: Unknown license compatibility between outbound 'GPL-2.0-only' and inbound 'HPND'
 ```
 
-Flict exit with an error if any problems were identified.
+Flict exits with an error if any problems were identified.
 
 
 # Force verify an outbound license expression against an inbound license expression
 
-To verify, and continue even if problems were found, that the above license expressions we can use the `--ignore-problems` option.
+To verify, and continue even if problems were found, use the `--ignore-problems` option.
 
 ```shell
 $ flict --ignore-problems verify -il HPND or X11 and BSD3 -ol GPL-2.0-only AND BSD-3-Clause

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ compatibility verification in your compliance work flow.
 
 flict can:
 
-* verify licenses compatibility for license expression and a packages and its dependencies
+* verify license compatibility for license expression and a package with dependencies
 
 * suggest candidate outbound licenses
 
@@ -31,13 +31,13 @@ flict can:
 
 * display, in misc format, compatibilities between licenses
 
-* ~~check outbound licenses against a policy (policy as supplied by the user)~~ (automatic now)
+* check outbound licenses against a policy (policy as supplied by the user)
 
 flict supports:
 
 * 104 licenses (```flict -of text list```)
 
-* common non SPDX ways to write licenses (e.g GPLv2 -> GPL-2.0-only) via [foss-licenses](https://github.com/hesa/foss-licenses)
+* normalizing common non SPDX ways to write licenses (e.g GPLv2 -> GPL-2.0-only) via [foss-licenses](https://github.com/hesa/foss-licenses)
 
 * adding your own licenses (and compatibilities), see "Extending the license db" in [SETTINGS](https://github.com/vinland-technology/flict/blob/main/SETTINGS.md)
 

--- a/example-data/europe.json
+++ b/example-data/europe.json
@@ -11,16 +11,19 @@
         "dependencies": [
             {
                 "name": "Sweden",
+                "version": "1234",
                 "license": "GPL-2.0-only or Apache-2.0",
                 "dependencies": [
                     {
                         "name": "Gothenburg",
+                        "version": "5678",
                         "license": "BSD-3-Clause",
                         "dependencies": [
                         ]
                     },
                     {
                         "name": "Stockholm",
+                        "version": "91011",
                         "license": "MIT",
                         "dependencies": []
                     }
@@ -29,16 +32,19 @@
             },
             {
                 "name": "Germany",
+                "version": "1112",
                 "license": "GPL-2.0-or-later or MIT and BSD-3-Clause or Apache-2.0",
                 "dependencies": [
                     {
                         "name": "Dusseldorf",
+                        "version": "1213",
                         "license": "GPL-2.0-or-later",
                         "dependencies": [
                         ]
                     },
                     {
                         "name": "Berlin",
+                        "version": "1415",
                         "license": "MIT or MPL-1.1",
                         "dependencies": []
                     }

--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -147,10 +147,10 @@ def parse():
 
     # verify
     parser_v = subparsers.add_parser(
-        'verify', help='verify license compatibility')
+        'verify', help='Verify license compatibility between for a package or an outbound license expression against inbound license expression.')
     parser_v.set_defaults(which="verify", func=verify)
-    parser_v.add_argument('--outbound-license', '-ol', type=str, nargs="+", dest='out_license', help='Outbound license for the licenses to verify compatibibility', default=None)
-    parser_v.add_argument('--inbound-license', '-il', type=str, nargs='+', dest='in_license_expr', help='Inbound license(s) for the licenses to verify compatibibility', default=[])
+    parser_v.add_argument('--outbound-license', '-ol', type=str, nargs="+", dest='out_license', help='Outbound license expressions', default=None)
+    parser_v.add_argument('--inbound-license', '-il', type=str, nargs='+', dest='in_license_expr', help='Inbound license expression', default=[])
     parser_v.add_argument('--sbom', '-s', type=str, dest='verify_sbom', help='SBoM file to verify')
     parser_v.add_argument('--sbom-dirs', '-sd', type=str, nargs='+', dest='sbom_dirs', help='Directories where SBoM files are searched for.', default='.')
     parser_v.add_argument('--flict', '-f', type=str, dest='verify_flict', help='Flict project file to verify')
@@ -160,14 +160,14 @@ def parse():
 
     # simplify
     parser_si = subparsers.add_parser(
-        'simplify', help='expand and simplify license expression')
+        'simplify', help='Expand and simplify a license expression')
     parser_si.set_defaults(which="simplify", func=simplify)
     parser_si.add_argument('license_expression', type=str, nargs='+',
-                           help='license expression to simplify')
+                           help='License expression to simplify')
 
     # list
     parser_li = subparsers.add_parser(
-        'list', help='list supported licenses')
+        'list', help='List supported licenses')
     parser_li.set_defaults(which="list", func=list_licenses)
     parser_li.add_argument('-t', '--translations',
                            dest='list_translation',
@@ -181,19 +181,19 @@ def parse():
 
     # display-compatibility
     parser_d = subparsers.add_parser(
-        'display-compatibility', help='display license compatibility graphically')
+        'display-compatibility', help='Display license compatibility graphically')
     parser_d.set_defaults(which="display-compatibility",
                           func=display_compatibility)
     parser_d.add_argument('license_expression', type=str, nargs='+',
-                          help='license expression to display compatibility for')
+                          help='Licenses, separated by space, to display compatibility for')
 
     # outbound-candidates
     parser_s = subparsers.add_parser(
-        'outbound-candidate', help='suggest outbound license candidates')
+        'outbound-candidate', help='Suggest outbound license candidates')
     parser_s.set_defaults(which="outbound-candidate",
                           func=suggest_outbound_candidate)
     parser_s.add_argument('license_expression', type=str, nargs='+',
-                          help='license expression to suggest candidate outbound license for')
+                          help='License expression to suggest candidate outbound license for')
 
     # policy-report
     parser_p = subparsers.add_parser(

--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -270,4 +270,3 @@ class Arbiter:
 
     def license_compatibility_as(self, expr):
         return compatible_license_short(expr)
-    

--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -25,7 +25,7 @@ class Arbiter:
         """
         self.update_dual = update_dual
         self.license_compatibility = LicenseCompatibilty(
-            license_db=license_db, licenses_preferences=licenses_preferences, denied_licenses=denied_licenses)
+            license_db=license_db, licenses_preferences=licenses_preferences, denied_licenses=denied_licenses, update_dual=update_dual)
 
     def supported_licenses(self):
         """Returns the supported licenses"""
@@ -267,3 +267,7 @@ class Arbiter:
 
     def licenses(self, expr):
         return self.license_compatibility.licenses(expr)
+
+    def license_compatibility_as(self, expr):
+        return compatible_license_short(expr)
+    

--- a/flict/flictlib/lic_comp.py
+++ b/flict/flictlib/lic_comp.py
@@ -18,8 +18,8 @@ COMPATIBILITY_TAG = "compatibility"
 
 class LicenseCompatibilty:
 
-    def __init__(self, license_db=None, licenses_preferences=None, denied_licenses=None):
-        self.license = License(denied_licenses)
+    def __init__(self, license_db=None, licenses_preferences=None, denied_licenses=None, update_dual=True):
+        self.license = License(denied_licenses, update_dual)
 
         self.compatibility = CompatibilityFactory.get_compatibility(license_db)
 

--- a/flict/flictlib/license.py
+++ b/flict/flictlib/license.py
@@ -23,9 +23,10 @@ class License():
     GPL-2.0-or-later or (GPL-3.0-only WITH GCC-exception-3.1 AND curl
     """
 
-    def __init__(self, denied_licenses, alias=None):
+    def __init__(self, denied_licenses, update_dual=True):
         self._denied_licenses = denied_licenses
         self.parser = LicenseParserFactory.get_parser()
+        self.update_dual = update_dual
 
     def get_license(self, expr):
         return self.parser.parse_license(expr)['license']
@@ -55,7 +56,7 @@ class License():
 
     def simplify_license(self, expr):
         try:
-            aliased = compatible_license_short(expr)
+            aliased = compatible_license_short(expr, self.update_dual)
             parsed = self.parser.parse_license([aliased])
             simplified = str(parsed['simplified'])
             return {

--- a/flict/impl.py
+++ b/flict/impl.py
@@ -30,7 +30,10 @@ class FlictImpl:
         return self.arbiter.extend_license_db(self._args.license_file, oformat=self._args.output_format, default_no=self._args.default_no)
 
     def display_compatibility(self):
-        inter_compats = self.arbiter.check_compatibilities(self._args.license_expression)
+        compat_list = []
+        for lic in self._args.license_expression:
+            compat_list.append(self.arbiter.license_compatibility_as(lic))
+        inter_compats = self.arbiter.check_compatibilities(compat_list)
         return self._formatter.format_compats(inter_compats)
 
     def simplify(self):
@@ -86,7 +89,10 @@ class FlictImpl:
 
         licenses_denied = self._read_json_object(licenses_denied_file, "licenses_denied", [])
         licenses_preferences = self._read_json_object(licenses_preference_file, "license_preferences", [])
-        arbiter = Arbiter(license_db=self._args.license_matrix_file, licenses_preferences=licenses_preferences, denied_licenses=licenses_denied)
+        arbiter = Arbiter(license_db=self._args.license_matrix_file,
+                          licenses_preferences=licenses_preferences,
+                          denied_licenses=licenses_denied,
+                          update_dual=not self._args.no_relicense)
 
         return arbiter
 

--- a/tests/args_mock.py
+++ b/tests/args_mock.py
@@ -30,6 +30,7 @@ class ArgsMock:
     suggest_outbound_candidate = False
     out_license = None
     in_license = None
+    no_relicense = False
     ignore_problems = False
     verbose : str = False
     version : str = False

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,6 +9,8 @@ from flict.flictlib.return_codes import FlictError, ReturnCodes
 from flict.impl import FlictImpl
 from tests.args_mock import ArgsMock
 
+import license_expression
+
 TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 def test_exceptions():
@@ -24,11 +26,9 @@ def test_exceptions():
 
     assert _error.value.args[0] == ReturnCodes.RET_INVALID_EXPRESSSION
 
-    with pytest.raises(FlictError) as _error:
+    with pytest.raises(license_expression.ExpressionParseError) as _error:
         args = ArgsMock(license_expression=['MIT ...'])
         FlictImpl(args).display_compatibility()
-
-    assert _error.value.args[0] == ReturnCodes.RET_INVALID_EXPRESSSION
 
     with pytest.raises(FlictError) as _error:
         prj = os.path.join(TEST_DIR, 'example-data')


### PR DESCRIPTION
These commit relates to #336 

* Separating between "license" and "license expression" in docs and code

* make expansion of dual license, e.g. `GPL-2.0-or-later` => `GPL-2.0-only OR GPL-3.0-only` optional

 