### PR TITLE
Hesa add allowed

### DIFF
--- a/flict/__main__.py
+++ b/flict/__main__.py
@@ -78,6 +78,8 @@ def parse():
 
     commmon_defaults_group.add_argument('--licenses-denied-file', '-ldf', type=str, dest='licenses_denied_file', help='', default=None)
 
+    commmon_defaults_group.add_argument('--licenses-allowed-file', '-laf', type=str, dest='licenses_allowed_file', help='', default=None)
+
     commmon_defaults_group.add_argument('--licenses-preference-file', '-lpf', type=str, dest='licenses_preference_file', help='', default=None)
 
     commmon_defaults_group.add_argument('--license-info-file', '-lif', type=str, dest='licenses_info_file', help='Short for applying -lmf <file> -ldf <file> -lpf <file>', default=None)

--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -16,16 +16,17 @@ from flict.flictlib.project.reader import FlictProjectReader
 class Arbiter:
     """Arbiter is a class to verify compatibility"""
 
-    def __init__(self, license_db=None, licenses_preferences=None, denied_licenses=None, update_dual=True):
+    def __init__(self, license_db=None, licenses_preferences=None, denied_licenses=None, allowed_licenses=None, update_dual=True):
         """Initializes Arbiter objects
              Parameters:
                  license_db: license database to use instead of builtin
                  licenses_preferences: license preferences to use instead of builtin
                  denied_licenses: licenses that cannot be used
+                 allowed_licenses: licenses that are the only ones to be used
         """
         self.update_dual = update_dual
         self.license_compatibility = LicenseCompatibilty(
-            license_db=license_db, licenses_preferences=licenses_preferences, denied_licenses=denied_licenses, update_dual=update_dual)
+            license_db=license_db, licenses_preferences=licenses_preferences, denied_licenses=denied_licenses, allowed_licenses=allowed_licenses, update_dual=update_dual)
 
     def supported_licenses(self):
         """Returns the supported licenses"""

--- a/flict/flictlib/arbiter.py
+++ b/flict/flictlib/arbiter.py
@@ -32,6 +32,10 @@ class Arbiter:
         """Returns the supported licenses"""
         return self.license_compatibility.supported_licenses()
 
+    def license_allowed(self, lic):
+        """Return whether or not a license is allowed"""
+        return self.license_compatibility.license.license_allowed(lic)
+
     def _verify_package(self, package, licenses):
         """Verifies a package's license to a list of outbounds and returns the
         compatibility between the liceses.

--- a/flict/flictlib/lic_comp.py
+++ b/flict/flictlib/lic_comp.py
@@ -18,8 +18,8 @@ COMPATIBILITY_TAG = "compatibility"
 
 class LicenseCompatibilty:
 
-    def __init__(self, license_db=None, licenses_preferences=None, denied_licenses=None, update_dual=True):
-        self.license = License(denied_licenses, update_dual)
+    def __init__(self, license_db=None, licenses_preferences=None, denied_licenses=None, allowed_licenses=None, update_dual=True):
+        self.license = License(denied_licenses, allowed_licenses, update_dual)
 
         self.compatibility = CompatibilityFactory.get_compatibility(license_db)
 

--- a/flict/flictlib/license.py
+++ b/flict/flictlib/license.py
@@ -23,8 +23,14 @@ class License():
     GPL-2.0-or-later or (GPL-3.0-only WITH GCC-exception-3.1 AND curl
     """
 
-    def __init__(self, denied_licenses, update_dual=True):
+    def __init__(self, denied_licenses, allowed_licenses, update_dual=True):
         self._denied_licenses = denied_licenses
+        self._allowed_licenses = allowed_licenses
+        # Either denied or allower or none: OK
+        # Both: not OK, raise exception
+        if self._denied_licenses and self._allowed_licenses:
+            raise FlictError(ReturnCodes.RET_CONFLICT_LICENSE_LIST, f'You can only supply either of denied or allowed licenses, not both.')
+
         self.parser = LicenseParserFactory.get_parser()
         self.update_dual = update_dual
 
@@ -46,9 +52,14 @@ class License():
     def denied_licenses(self):
         return self._denied_licenses
 
+    def allowed_licenses(self):
+        return self._allowed_licenses
+
     def license_denied(self, license_):
         if self._denied_licenses:
             return license_ in self._denied_licenses
+        if self._allowed_licenses:
+            return not license_ in self._allowed_licenses
         return False
 
     def license_allowed(self, license_):

--- a/flict/flictlib/license.py
+++ b/flict/flictlib/license.py
@@ -29,7 +29,7 @@ class License():
         # Either denied or allower or none: OK
         # Both: not OK, raise exception
         if self._denied_licenses and self._allowed_licenses:
-            raise FlictError(ReturnCodes.RET_CONFLICT_LICENSE_LIST, f'You can only supply either of denied or allowed licenses, not both.')
+            raise FlictError(ReturnCodes.RET_CONFLICT_LICENSE_LIST, 'You can only supply either of denied or allowed licenses, not both.')
 
         self.parser = LicenseParserFactory.get_parser()
         self.update_dual = update_dual
@@ -59,7 +59,7 @@ class License():
         if self._denied_licenses:
             return license_ in self._denied_licenses
         if self._allowed_licenses:
-            return not license_ in self._allowed_licenses
+            return license_ not in self._allowed_licenses
         return False
 
     def license_allowed(self, license_):

--- a/flict/flictlib/return_codes.py
+++ b/flict/flictlib/return_codes.py
@@ -30,6 +30,7 @@ class ReturnCodes(Enum):
     RET_FILE_NOT_FOUND = (12, "File not found")
     RET_INVALID_LICENSE_PREFERENCE = (13, "Invalid license preferences")
     RET_INVALID_MATRIX = (14, "Invalid matrix or matrix extension")
+    RET_CONFLICT_LICENSE_LIST = (15, "Conflicting allowed/denied license lists")
 
     @classmethod
     def get_help(cls, indent="  "):

--- a/flict/impl.py
+++ b/flict/impl.py
@@ -81,6 +81,7 @@ class FlictImpl:
 
     def _get_arbiter(self):
         licenses_denied_file = self._args.licenses_denied_file
+        licenses_allowed_file = self._args.licenses_allowed_file
         licenses_preference_file = self._args.licenses_preference_file
 
         if self._args.licenses_info_file:
@@ -88,10 +89,12 @@ class FlictImpl:
             licenses_preference_file = self._args.licenses_info_file
 
         licenses_denied = self._read_json_object(licenses_denied_file, "licenses_denied", [])
+        licenses_allowed = self._read_json_object(licenses_allowed_file, "licenses_allowed", [])
         licenses_preferences = self._read_json_object(licenses_preference_file, "license_preferences", [])
         arbiter = Arbiter(license_db=self._args.license_matrix_file,
                           licenses_preferences=licenses_preferences,
                           denied_licenses=licenses_denied,
+                          allowed_licenses=licenses_allowed,
                           update_dual=not self._args.no_relicense)
 
         return arbiter

--- a/tests/args_mock.py
+++ b/tests/args_mock.py
@@ -25,6 +25,7 @@ class ArgsMock:
     verify_sbom = None
     alias_file = None
     licenses_denied_file = None
+    licenses_allowed_file = None
     licenses_preference_file = None
     licenses_info_file = None
     suggest_outbound_candidate = False

--- a/tests/test_allowed.py
+++ b/tests/test_allowed.py
@@ -10,12 +10,33 @@
 import json
 import pytest
 
+from flict.flictlib.license import License
 from flict.flictlib.arbiter import Arbiter
 from flict.flictlib.return_codes import FlictError, ReturnCodes
 from flict.flictlib.project.reader import ProjectReaderFactory
 
 reader = ProjectReaderFactory.get_projectreader(project_format="spdx", project_dirs=["example-data"], update_dual=False)
 freetype = reader.read_project("example-data/freetype-2.9.spdx.json")
+
+def test_license_clean():
+    lic = License(None, None)
+    assert lic.license_allowed('MIT')
+
+def test_license_allowed():
+    lic = License(None, ['MIT'])
+    assert lic.license_allowed('MIT')
+
+def test_license_allowed_false():
+    lic = License(None, ['MIT'])
+    assert not lic.license_allowed('X11')
+
+def test_license_denined():
+    lic = License(['MIT'], None)
+    assert lic.license_denied('MIT')
+
+def test_license_denied_false():
+    lic = License(['MIT'], None)
+    assert not lic.license_denied('X11')
 
 def test_freetype_verification():
     # normal verification

--- a/tests/test_allowed.py
+++ b/tests/test_allowed.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2024 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+#
+# test passing a list of allowed licenses to arbiter. All of these should not be returned
+# as allowed outbound licenses after a verification of a project (freetype)
+#
+
+import json
+import pytest
+
+from flict.flictlib.arbiter import Arbiter
+from flict.flictlib.return_codes import FlictError, ReturnCodes
+from flict.flictlib.project.reader import ProjectReaderFactory
+
+reader = ProjectReaderFactory.get_projectreader(project_format="spdx", project_dirs=["example-data"], update_dual=False)
+freetype = reader.read_project("example-data/freetype-2.9.spdx.json")
+
+def test_freetype_verification():
+    # normal verification
+    arbiter = Arbiter(update_dual=False)
+    verification = arbiter.verify(freetype)
+    allowed_outbounds = verification['packages'][0]['allowed_outbound_licenses']
+    expected_allowed = ['FTL', 'Libpng', 'Zlib', 'GPL-2.0-or-later']
+    expected_allowed.sort()
+    allowed_outbounds.sort()
+    assert allowed_outbounds == expected_allowed
+
+def test_freetype_verification_allowed():
+    # verification with allowed licenses: 'FTL' 
+    arbiter = Arbiter(allowed_licenses=['FTL'], update_dual=False)
+    verification = arbiter.verify(freetype)
+    allowed_outbounds = verification['packages'][0]['allowed_outbound_licenses']
+    expected_allowed = ['FTL']
+    expected_allowed.sort()
+    allowed_outbounds.sort()
+    assert allowed_outbounds == expected_allowed
+
+def test_freetype_verification_allowed():
+    # verification with allowed licenses: 'FTL', 'Zlib' 
+    arbiter = Arbiter(allowed_licenses=['FTL', 'Zlib'], update_dual=False)
+    verification = arbiter.verify(freetype)
+    allowed_outbounds = verification['packages'][0]['allowed_outbound_licenses']
+    expected_allowed = ['FTL', 'Zlib']
+    expected_allowed.sort()
+    allowed_outbounds.sort()
+    assert allowed_outbounds == expected_allowed
+
+def test_freetype_verification_allowed_denied():
+    # verification with allowed and denied licenses: should raise error
+    with pytest.raises(FlictError) as _error:
+        arbiter = Arbiter(allowed_licenses=['FTL', 'Zlib'], denied_licenses=['FTL', 'Zlib'], update_dual=False)


### PR DESCRIPTION
New option: `--licenses-allowed-file`,  `-laf`

With this option you can pass a list of licenses to (only) allow as outbound licenses.

This option cannot be used together with `--licenses-denied-file`, `-ldf`. Doing so, results in an error.

Examples:

Without any licenses to allow/deny:
```
$ flict -of text  outbound-candidate  "MIT OR BSD-3-Clause AND (X11)" 
BSD-3-Clause, MIT, X11
```

Denying `MIT` using `example-data/denied-licenses.json`:
```
$ cat example-data/denied-licenses.json
{
    "licenses_denied": [ "MIT" ]
}
$ flict -of text -ldf example-data/denied-licenses.json  outbound-candidate  "MIT OR BSD-3-Clause AND (X11)" 
BSD-3-Clause, X11
```

Allowing `MIT` using the file `example-data/allowed-licenses.json`:
```
$ cat example-data/allowed-licenses.json
{
    "licenses_allowed": [ "MIT" ]
}
$ flict -of text -laf example-data/allowed-licenses.json  outbound-candidate  "MIT OR BSD-3-Clause AND (X11)" 
MIT
```
