### PR TITLE
Fix test: catch flame exception instead of license_expression

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,7 +9,7 @@ from flict.flictlib.return_codes import FlictError, ReturnCodes
 from flict.impl import FlictImpl
 from tests.args_mock import ArgsMock
 
-import license_expression
+from flame.exception import FlameException
 
 TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -26,7 +26,7 @@ def test_exceptions():
 
     assert _error.value.args[0] == ReturnCodes.RET_INVALID_EXPRESSSION
 
-    with pytest.raises(license_expression.ExpressionParseError) as _error:
+    with pytest.raises(FlameException) as _error:
         args = ArgsMock(license_expression=['MIT ...'])
         FlictImpl(args).display_compatibility()
 


### PR DESCRIPTION
On faulty license expression, e.g. "MIT ....."
* previously license_expression raised exception
* now flame does license parsing and raises flame exception